### PR TITLE
`origin_at_bottom` and `height` arguments and options

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,46 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # - {os: macOS-latest,   r: 'release'}
+          # - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: rcmdcheck
+
+      - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,30 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: test-coverage
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: covr
+
+      - name: Test coverage
+        run: covr::codecov()
+        shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dee
 Type: Package
 Title: 'd' Attribute Tools
-Version: 0.1.0-1
+Version: 0.1.0-2
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")))
@@ -11,12 +11,13 @@ Description: Utilities to build an svg path 'd' <https://developer.mozilla.org/e
 Depends:
     R (>= 4.2)
 Imports:
-    affiner,
+    affiner (>= 0.2.0),
     rlang,
     vctrs
 Suggests:
     omsvg,
     testthat
+Remotes: trevorld/affiner
 License: MIT + file LICENSE
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1

--- a/R/path.r
+++ b/R/path.r
@@ -36,8 +36,8 @@ M <- function(x, y = NULL, ...,
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y <- height - y
     }
     paste(c("M", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
@@ -52,8 +52,8 @@ mm <- function(x, y = NULL, ...,
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y <- height - y
     }
     paste(c("m", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
@@ -92,8 +92,8 @@ L <- function(x, y = NULL, ...,
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y <- height - y
     }
     paste(c("L", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
@@ -108,8 +108,8 @@ ll <- function(x, y = NULL, ...,
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y <- height - y
     }
     paste(c("l", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
@@ -159,8 +159,8 @@ V <- function(y, ...,
               height = getOption("dee.height", NULL)) {
     check_dots_empty()
     stopifnot(is.numeric(y))
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y <- height - y
     }
     paste(c("V", y), collapse = " ") |> dee()
 }
@@ -172,8 +172,8 @@ vv <- function(y, ...,
                height = getOption("dee.height", NULL)) {
     check_dots_empty()
     stopifnot(is.numeric(y))
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y <- height - y
     }
     paste(c("v", y), collapse = " ") |> dee()
 }
@@ -216,9 +216,9 @@ Q <- function(x1, y1 = NULL, x, y = NULL, ...,
     y1 <- p1$y
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y1 <- getOption("dee.height") - y1
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y1 <- height - y1
+        y <- height - y
     }
     xy1 <- paste(x1, y1, sep = sep)
     xy <- paste(x, y, sep = sep)
@@ -238,9 +238,9 @@ qq <- function(x1, y1 = NULL, x, y = NULL, ...,
     y1 <- p1$y
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y1 <- getOption("dee.height") - y1
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y1 <- height - y1
+        y <- height - y
     }
     xy1 <- paste(x1, y1, sep = sep)
     xy <- paste(x, y, sep = sep)
@@ -269,8 +269,8 @@ T <- function(x, y = NULL, ...,
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y <- height - y
     }
     paste(c("T", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
@@ -285,8 +285,8 @@ tt <- function(x, y = NULL, ...,
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y <- height - y
     }
     paste(c("t", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
@@ -332,10 +332,10 @@ C <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, ...,
     y2 <- p2$y
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y2 <- getOption("dee.height") - y2
-        y1 <- getOption("dee.height") - y1
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y2 <- height - y2
+        y1 <- height - y1
+        y <- height - y
     }
     xy1 <- paste(x1, y1, sep = sep)
     xy2 <- paste(x2, y2, sep = sep)
@@ -359,10 +359,10 @@ cc <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL,...,
     y2 <- p2$y
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y2 <- getOption("dee.height") - y2
-        y1 <- getOption("dee.height") - y1
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y2 <- height - y2
+        y1 <- height - y1
+        y <- height - y
     }
     xy1 <- paste(x1, y1, sep = sep)
     xy2 <- paste(x2, y2, sep = sep)
@@ -395,9 +395,9 @@ S <- function(x2, y2 = NULL, x, y = NULL,...,
     y2 <- p2$y
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y2 <- getOption("dee.height") - y2
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y2 <- height - y2
+        y <- height - y
     }
     xy2 <- paste(x2, y2, sep = sep)
     xy <- paste(x, y, sep = sep)
@@ -417,9 +417,9 @@ ss <- function(x2, y2 = NULL, x, y = NULL, ...,
     y2 <- p2$y
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y2 <- getOption("dee.height") - y2
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y2 <- height - y2
+        y <- height - y
     }
     xy2 <- paste(x2, y2, sep = sep)
     xy <- paste(x, y, sep = sep)
@@ -446,16 +446,21 @@ sz <- function(...) {
 #' @inheritParams M
 #' @param rx,ry Radius of ellipse.
 #' @param x_axis_rotation Angle (in degrees) from x-axis of ellipse.
+#'                        Will be coerced by [affiner::degrees()].
+#'                        If `isTRUE(origin_at_bottom)` will multiply by `-1`.
 #' @param large_arc_flag If `TRUE` then one of two larger arc sweeps chosen else
 #'                       one of the two smaller arc sweeps.
 #' @param sweep_flag If `TRUE` then arc will be drawn in "positive-angle" direction.
 #'                   else drawn in "negative-angle" direction.
+#'                   If `isTRUE(origin_at_bottom)` will invert.
 #' @return A [dee()] object.
 #' @examples
 #' M(1, 1) + A(rx = 1, x = 2, y = 2) + Z()
 #' M(1, 1) + aa(rx = 1, x = 1, y = 1) + zz()
 #' @export
-A <- function(rx, ry = rx, x_axis_rotation = 0, large_arc_flag = FALSE, sweep_flag = FALSE, x, y = NULL, ...,
+A <- function(rx, ry = rx,
+              x_axis_rotation = 0, large_arc_flag = FALSE, sweep_flag = FALSE,
+              x, y = NULL, ...,
               sep = getOption("dee.sep", ","),
               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
               height = getOption("dee.height", NULL)) {
@@ -463,15 +468,20 @@ A <- function(rx, ry = rx, x_axis_rotation = 0, large_arc_flag = FALSE, sweep_fl
     stopifnot(is.numeric(rx), is.numeric(rx))
     rxy <- paste(rx, ry, sep = sep)
 
+    x_axis_rotation <- as.numeric(affiner::degrees(x_axis_rotation))
     large_arc <- as.integer(as.logical(large_arc_flag))
     sweep <- as.integer(as.logical(sweep_flag))
+    if (isTRUE(origin_at_bottom)) {
+        sweep <- 1L - sweep
+        x_axis_rotation <- -x_axis_rotation
+    }
     rls <- paste(x_axis_rotation, large_arc, sweep, sep = sep)
 
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y <- height - y
     }
     xy <- paste(x, y, sep = sep)
     paste(c("A", paste(rxy, rls, xy)), collapse = " ") |> dee()
@@ -494,8 +504,8 @@ aa <- function(rx, ry = rx, x_axis_rotation = 0, large_arc_flag = FALSE, sweep_f
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
-    if (isTRUE(getOption("dee.origin_at_bottom"))) {
-        y <- getOption("dee.height") - y
+    if (isTRUE(origin_at_bottom)) {
+        y <- height - y
     }
     xy <- paste(x, y, sep = sep)
     paste(c("a", paste(rxy, rls, xy)), collapse = " ") |> dee()

--- a/R/path.r
+++ b/R/path.r
@@ -3,6 +3,9 @@
 #' `Z()` and `zz()` connects the initial point of the current subpath with the last point (with a straight line if these are different).  There is no difference between `Z()` and `zz()`.
 #'
 #' @return A [dee()] object.
+#' @examples
+#' M(1, 1) + L(2, 2) + Z()
+#' M(1, 1) + ll(2, 2) + zz()
 #' @export
 Z <- function() dee("Z")
 
@@ -18,21 +21,40 @@ zz <- function() dee("z")
 #'          Else a numeric vector.
 #' @param y Either `NULL` or a numeric vector.
 #' @param sep Either `","` or `" "`.
+#' @param origin_at_bottom,height If `origin_at_bottom` is `TRUE` then
+#'                                `y` (and any `y1` and `y2`) coordinates is transformed by `height - y`.
 #' @return A [dee()] object.
+#' @examples
+#' M(1, 1) + L(2, 2) + Z()
+#' M(1, 1) + ll(1, 1) + zz()
 #' @export
-M <- function(x, y = NULL, sep = getOption("dee.sep", ",")) {
+M <- function(x, y = NULL, ...,
+              sep = getOption("dee.sep", ","),
+              origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+              height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y <- getOption("dee.height") - y
+    }
     paste(c("M", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
 #' @rdname M
 #' @export
-mm <- function(x, y = NULL, sep = getOption("dee.sep", ",")) {
+mm <- function(x, y = NULL, ...,
+               sep = getOption("dee.sep", ","),
+               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+               height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y <- getOption("dee.height") - y
+    }
     paste(c("m", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
@@ -55,23 +77,40 @@ mz <- function(...) {
 #' `H()` and `hh()` draw horizontal lines, and
 #' `V()` and `vv()` draw vertical lines.
 # `LZ()`, `lz()`, `HZ()`, `hz()`, `VZ()`, and `vz()` are variants that automatically add a "closepath".
-#' 
+#'
 #' @inheritParams M
+#' @examples
+#' M(1, 1) + L(2, 2) + Z()
+#' M(1, 1) + ll(1, 1) + zz()
 #' @return A [dee()] object.
 #' @export
-L <- function(x, y = NULL, sep = getOption("dee.sep", ",")) {
+L <- function(x, y = NULL, ...,
+              sep = getOption("dee.sep", ","),
+              origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+              height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y <- getOption("dee.height") - y
+    }
     paste(c("L", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
 #' @rdname L
 #' @export
-ll <- function(x, y = NULL, sep = getOption("dee.sep", ",")) {
+ll <- function(x, y = NULL, ...,
+               sep = getOption("dee.sep", ","),
+               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+               height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y <- getOption("dee.height") - y
+    }
     paste(c("l", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
@@ -115,15 +154,27 @@ hz <- function(...) {
 
 #' @rdname L
 #' @export
-V <- function(y) {
+V <- function(y, ...,
+              origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+              height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     stopifnot(is.numeric(y))
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y <- getOption("dee.height") - y
+    }
     paste(c("V", y), collapse = " ") |> dee()
 }
 
 #' @rdname L
 #' @export
-vv <- function(y) {
+vv <- function(y, ...,
+               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+               height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     stopifnot(is.numeric(y))
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y <- getOption("dee.height") - y
+    }
     paste(c("v", y), collapse = " ") |> dee()
 }
 
@@ -144,20 +195,31 @@ vz <- function(...) {
 #' `Q()` and `qq()` draw quadratic Bezier curves
 #' `T()` and `tt()` draw quadratic Bezier curves assuming the control point is the reflection of the previous Bezier curve command.
 # `QZ()`, `qz()`, `TZ()`, and `tz()` are variants that automatically add a "closepath".
-#' 
+#'
 #' @inheritParams M
 #' @param x1 If `y1` is `NULL` will be coerced by [affiner::as_coord2d()].
 #'          Else a numeric vector.
 #' @param y1 Either `NULL` or a numeric vector.
 #' @return A [dee()] object.
+#' @examples
+#' M(1, 1) + Q(2, 2, 3, 3) + T(4, 4) + Z()
+#' M(1, 1) + qq(1, 1, 2, 2) + tt(1, 1) + zz()
 #' @export
-Q <- function(x1, y1 = NULL, x, y = NULL, sep = getOption("dee.sep", ",")) {
+Q <- function(x1, y1 = NULL, x, y = NULL, ...,
+              sep = getOption("dee.sep", ","),
+              origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+              height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p1 <- as_coords(x1, y1)
     p <- as_coords(x, y)
     x1 <- p1$x
     y1 <- p1$y
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y1 <- getOption("dee.height") - y1
+        y <- getOption("dee.height") - y
+    }
     xy1 <- paste(x1, y1, sep = sep)
     xy <- paste(x, y, sep = sep)
     paste(c("Q", paste(xy1, xy)), collapse = " ") |> dee()
@@ -165,13 +227,21 @@ Q <- function(x1, y1 = NULL, x, y = NULL, sep = getOption("dee.sep", ",")) {
 
 #' @rdname Q
 #' @export
-qq <- function(x1, y1 = NULL, x, y = NULL, sep = getOption("dee.sep", ",")) {
+qq <- function(x1, y1 = NULL, x, y = NULL, ...,
+               sep = getOption("dee.sep", ","),
+               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+               height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p1 <- as_coords(x1, y1)
     p <- as_coords(x, y)
     x1 <- p1$x
     y1 <- p1$y
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y1 <- getOption("dee.height") - y1
+        y <- getOption("dee.height") - y
+    }
     xy1 <- paste(x1, y1, sep = sep)
     xy <- paste(x, y, sep = sep)
     paste(c("q", paste(xy1, xy)), collapse = " ") |> dee()
@@ -191,19 +261,33 @@ qz <- function(...) {
 
 #' @rdname Q
 #' @export
-T <- function(x, y = NULL, sep = getOption("dee.sep", ",")) {
+T <- function(x, y = NULL, ...,
+              sep = getOption("dee.sep", ","),
+              origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+              height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y <- getOption("dee.height") - y
+    }
     paste(c("T", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
 #' @rdname Q
 #' @export
-tt <- function(x, y = NULL, sep = getOption("dee.sep", ",")) {
+tt <- function(x, y = NULL, ...,
+               sep = getOption("dee.sep", ","),
+               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+               height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y <- getOption("dee.height") - y
+    }
     paste(c("t", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
@@ -224,14 +308,21 @@ tz <- function(...) {
 #' `C()` and `cc()` draw cubic Bezier curves
 #' `S()` and `ss()` draw cubic Bezier curves assuming the first control point is the reflection of the previous Bezier curve command.
 # `CZ()`, `cz()`, `SZ()`, and `sz()` are variants that automatically add a "closepath".
-#' 
+#'
 #' @inheritParams Q
 #' @param x2 If `y2` is `NULL` will be coerced by [affiner::as_coord2d()].
 #'          Else a numeric vector.
 #' @param y2 Either `NULL` or a numeric vector.
+#' @examples
+#' M(1, 1) + C(2, 2, 3, 3, 4, 4) + Z()
+#' M(1, 1) + cc(1, 1, 2, 2, 3, 3) + zz()
 #' @return A [dee()] object.
 #' @export
-C <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, sep = getOption("dee.sep", ",")) {
+C <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, ...,
+              sep = getOption("dee.sep", ","),
+              origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+              height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p1 <- as_coords(x1, y1)
     p2 <- as_coords(x2, y2)
     p <- as_coords(x, y)
@@ -241,6 +332,11 @@ C <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, sep = getOption("dee.se
     y2 <- p2$y
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y2 <- getOption("dee.height") - y2
+        y1 <- getOption("dee.height") - y1
+        y <- getOption("dee.height") - y
+    }
     xy1 <- paste(x1, y1, sep = sep)
     xy2 <- paste(x2, y2, sep = sep)
     xy <- paste(x, y, sep = sep)
@@ -249,7 +345,11 @@ C <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, sep = getOption("dee.se
 
 #' @rdname C
 #' @export
-cc <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, sep = getOption("dee.sep", ",")) {
+cc <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL,...,
+               sep = getOption("dee.sep", ","),
+               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+               height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p1 <- as_coords(x1, y1)
     p2 <- as_coords(x2, y2)
     p <- as_coords(x, y)
@@ -259,6 +359,11 @@ cc <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, sep = getOption("dee.s
     y2 <- p2$y
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y2 <- getOption("dee.height") - y2
+        y1 <- getOption("dee.height") - y1
+        y <- getOption("dee.height") - y
+    }
     xy1 <- paste(x1, y1, sep = sep)
     xy2 <- paste(x2, y2, sep = sep)
     xy <- paste(x, y, sep = sep)
@@ -279,13 +384,21 @@ cz <- function(...) {
 
 #' @rdname C
 #' @export
-S <- function(x2, y2 = NULL, x, y = NULL, sep = getOption("dee.sep", ",")) {
+S <- function(x2, y2 = NULL, x, y = NULL,...,
+              sep = getOption("dee.sep", ","),
+              origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+              height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p2 <- as_coords(x2, y2)
     p <- as_coords(x, y)
     x2 <- p2$x
     y2 <- p2$y
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y2 <- getOption("dee.height") - y2
+        y <- getOption("dee.height") - y
+    }
     xy2 <- paste(x2, y2, sep = sep)
     xy <- paste(x, y, sep = sep)
     paste(c("S", paste(xy2, xy)), collapse = " ") |> dee()
@@ -293,13 +406,21 @@ S <- function(x2, y2 = NULL, x, y = NULL, sep = getOption("dee.sep", ",")) {
 
 #' @rdname C
 #' @export
-ss <- function(x2, y2 = NULL, x, y = NULL, sep = getOption("dee.sep", ",")) {
+ss <- function(x2, y2 = NULL, x, y = NULL, ...,
+               sep = getOption("dee.sep", ","),
+               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+               height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     p2 <- as_coords(x2, y2)
     p <- as_coords(x, y)
     x2 <- p2$x
     y2 <- p2$y
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y2 <- getOption("dee.height") - y2
+        y <- getOption("dee.height") - y
+    }
     xy2 <- paste(x2, y2, sep = sep)
     xy <- paste(x, y, sep = sep)
     paste(c("s", paste(xy2, xy)), collapse = " ") |> dee()
@@ -321,7 +442,7 @@ sz <- function(...) {
 #'
 #' `A()` and `aa()` draw elliptical arc curve commands.
 # `AZ()` and `az()` are variants that automatically add a "closepath".
-#' 
+#'
 #' @inheritParams M
 #' @param rx,ry Radius of ellipse.
 #' @param x_axis_rotation Angle (in degrees) from x-axis of ellipse.
@@ -330,8 +451,15 @@ sz <- function(...) {
 #' @param sweep_flag If `TRUE` then arc will be drawn in "positive-angle" direction.
 #'                   else drawn in "negative-angle" direction.
 #' @return A [dee()] object.
+#' @examples
+#' M(1, 1) + A(rx = 1, x = 2, y = 2) + Z()
+#' M(1, 1) + aa(rx = 1, x = 1, y = 1) + zz()
 #' @export
-A <- function(rx, ry = rx, x_axis_rotation = 0, large_arc_flag = FALSE, sweep_flag = FALSE, x, y = NULL, sep = getOption("dee.sep", ",")) {
+A <- function(rx, ry = rx, x_axis_rotation = 0, large_arc_flag = FALSE, sweep_flag = FALSE, x, y = NULL, ...,
+              sep = getOption("dee.sep", ","),
+              origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+              height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     stopifnot(is.numeric(rx), is.numeric(rx))
     rxy <- paste(rx, ry, sep = sep)
 
@@ -342,13 +470,20 @@ A <- function(rx, ry = rx, x_axis_rotation = 0, large_arc_flag = FALSE, sweep_fl
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y <- getOption("dee.height") - y
+    }
     xy <- paste(x, y, sep = sep)
     paste(c("A", paste(rxy, rls, xy)), collapse = " ") |> dee()
 }
 
 #' @rdname A
 #' @export
-aa <- function(rx, ry = rx, x_axis_rotation = 0, large_arc_flag = FALSE, sweep_flag = FALSE, x, y = NULL, sep = getOption("dee.sep", ",")) {
+aa <- function(rx, ry = rx, x_axis_rotation = 0, large_arc_flag = FALSE, sweep_flag = FALSE, x, y = NULL,...,
+               sep = getOption("dee.sep", ","),
+               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+               height = getOption("dee.height", NULL)) {
+    check_dots_empty()
     stopifnot(is.numeric(rx), is.numeric(rx))
     rxy <- paste(rx, ry, sep = sep)
 
@@ -359,6 +494,9 @@ aa <- function(rx, ry = rx, x_axis_rotation = 0, large_arc_flag = FALSE, sweep_f
     p <- as_coords(x, y)
     x <- p$x
     y <- p$y
+    if (isTRUE(getOption("dee.origin_at_bottom"))) {
+        y <- getOption("dee.height") - y
+    }
     xy <- paste(x, y, sep = sep)
     paste(c("a", paste(rxy, rls, xy)), collapse = " ") |> dee()
 }

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -10,3 +10,7 @@ as_coords <- function(x, y = NULL) {
     }
     p
 }
+
+default_options <- list(dee.sep = ",",
+                        dee.origin_at_bottom = FALSE,
+                        dee.height = NULL)

--- a/README.Rmd
+++ b/README.Rmd
@@ -31,7 +31,6 @@ remotes::install_github("trevorld/dee")
 
 ```{r heart}
 library("dee", warn.conflicts = FALSE) # masks `stats::C()`
-library("omsvg")
 # https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d#example
 d <- M(10, 30) +
      A(20, 20, 0, 0, 1, 50, 30) +
@@ -44,9 +43,9 @@ print(d)
 ```
 
 ```{r heart_render, eval=eval_code, results="asis"}
+library("omsvg")
 SVG(width = 100, height = 100, viewbox = TRUE) |>
-    svg_path(d, fill="red", stroke="black", stroke_width=2) |>
-    as.character() |> cat()
+    svg_path(d, fill="red", stroke="black", stroke_width=2)
 ```
 
 Instead of explicitly indicating each `x` and `y` coordinate one
@@ -56,7 +55,6 @@ if they can be coerced by `affiner::as_coord2d()`.
 ```{r holed}
 library("affiner")
 library("dee", warn.conflicts = FALSE) # masks `stats::C()`
-library("omsvg")
 po <- as_coord2d(x = c(10, 10, 90, 90),
                  y = c(10, 90, 90, 10))
 pi <- po$clone()$
@@ -71,10 +69,10 @@ print(d)
 ```
 
 ```{r holed_render, eval=eval_code, results="asis"}
+library("omsvg")
 attrs <- svg_attrs_pres(fill_rule = "evenodd")
 SVG(width = 100, height = 100, viewbox = TRUE) |>
-    svg_path(d, fill = "cyan", stroke = "black", stroke_width = 2, attrs = attrs) |>
-    as.character() |> cat()
+    svg_path(d, fill = "cyan", stroke = "black", stroke_width = 2, attrs = attrs)
 ```
 
 One can used the `dee.origin_at_bottom` and `dee.height` options if one
@@ -84,7 +82,6 @@ with R graphics) instead of the top left corner (as is typical with the svg form
 ```{r origin_at_bottom}
 library("affiner")
 library("dee", warn.conflicts = FALSE) # masks `stats::C()`
-library("omsvg")
 p <- as_coord2d(x = c(10, 40, 70),
                 y = c(10, 40, 10))
 t1 <- MZ(p)
@@ -96,11 +93,10 @@ print(t2)
 ```
 
 ```{r origin_at_bottom_render, eval=eval_code, results="asis"}
-attrs <- svg_attrs_pres(fill_rule = "evenodd")
+library("omsvg")
 SVG(width = 100, height = 100, viewbox = TRUE) |>
-    svg_path(t1, fill = "cyan", stroke = "black", stroke_width = 2, attrs = attrs) |>
-    svg_path(t2, fill = "orange", stroke = "black", stroke_width = 2, attrs = attrs) |>
-    as.character() |> cat()
+    svg_path(t1, fill = "cyan", stroke = "black", stroke_width = 2) |>
+    svg_path(t2, fill = "orange", stroke = "black", stroke_width = 2)
 ```
 
 ## <a name="related">Related links</a>

--- a/README.Rmd
+++ b/README.Rmd
@@ -11,13 +11,15 @@
 * [Examples](#examples)
 * [Related links](#related)
 
+```{r setup, results="none", echo=FALSE}
+eval_code <- requireNamespace("omsvg", quietly = TRUE)
+```
+
 ## <a name="overview">Overview</a>
 
 The `{dee}` package provides helper functions to construct a string of the [`d` attribute of svg paths](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d).  Such svg path strings can be used with `omsvg::svg_path()` or in a bespoke svg creation function.
 
-In particular [FontForge](https://fontforge.org/docs/index.html) cannot import svg glyphs created by `svglite::svglite()` very well and `omsvg::svg_path()` provides no help in constructing an svg path `d` attribute:
-
-> A path can potentially be quite complex (with an interplay of line and curve commands), so, a hand-encoded `path` string is not often done by hand. For this reason, the `path` argument accepts only a formatted string that complies with the input requirements for the d attribute of the SVG `<path>` tag.
+In particular I want to generate some svg images of font glyphs to import into [FontForge](https://fontforge.org/docs/index.html) which doesn't seem to import svg glyphs created by `svglite::svglite()` very well and `omsvg::svg_path()` provides no help in constructing an svg path `d` attribute.
 
 ## <a name="installation">Installation</a>
 
@@ -27,7 +29,7 @@ remotes::install_github("trevorld/dee")
 
 ## <a name="examples">Examples</a>
 
-```{r heart, eval=requireNamespace("omsvg"), results="asis"}
+```{r heart}
 library("dee", warn.conflicts = FALSE) # masks `stats::C()`
 library("omsvg")
 # https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d#example
@@ -38,13 +40,22 @@ d <- M(10, 30) +
      Q(10, 60, 10, 30) +
      Z()
 
-SVG(width = 100, height = 100, viewbox = TRUE) |>
-    svg_path(d, fill="red", stroke="black", stroke_width=2)
+print(d)
 ```
 
-```{r holed, eval=requireNamespace("omsvg"), results="asis"}
+```{r heart_render, eval=eval_code, results="asis"}
+SVG(width = 100, height = 100, viewbox = TRUE) |>
+    svg_path(d, fill="red", stroke="black", stroke_width=2) |>
+    as.character() |> cat()
+```
+
+Instead of explicitly indicating each `x` and `y` coordinate one
+can also use objects that contain both `x` and `y` coordinates
+if they can be coerced by `affiner::as_coord2d()`.
+
+```{r holed}
 library("affiner")
-library("dee")
+library("dee", warn.conflicts = FALSE) # masks `stats::C()`
 library("omsvg")
 po <- as_coord2d(x = c(10, 10, 90, 90),
                  y = c(10, 90, 90, 10))
@@ -52,12 +63,44 @@ pi <- po$clone()$
     translate(-mean(po))$
     scale(0.5)$
     rotate(45)$
-    translate(mean(po))
+    translate(mean(po)) |>
+    round()
 
 d <- MZ(po) + MZ(pi)
+print(d)
+```
+
+```{r holed_render, eval=eval_code, results="asis"}
 attrs <- svg_attrs_pres(fill_rule = "evenodd")
 SVG(width = 100, height = 100, viewbox = TRUE) |>
-    svg_path(d, fill = "cyan", stroke = "black", stroke_width = 2, attrs = attrs)
+    svg_path(d, fill = "cyan", stroke = "black", stroke_width = 2, attrs = attrs) |>
+    as.character() |> cat()
+```
+
+One can used the `dee.origin_at_bottom` and `dee.height` options if one
+prefers to think of the origin being at the bottom left corner (as is typical
+with R graphics) instead of the top left corner (as is typical with the svg format).
+
+```{r origin_at_bottom}
+library("affiner")
+library("dee", warn.conflicts = FALSE) # masks `stats::C()`
+library("omsvg")
+p <- as_coord2d(x = c(10, 40, 70),
+                y = c(10, 40, 10))
+t1 <- MZ(p)
+t2 <- rlang::with_options(MZ(p),
+                          dee.origin_at_bottom = TRUE,
+                          dee.height = 100)
+print(t1)
+print(t2)
+```
+
+```{r origin_at_bottom_render, eval=eval_code, results="asis"}
+attrs <- svg_attrs_pres(fill_rule = "evenodd")
+SVG(width = 100, height = 100, viewbox = TRUE) |>
+    svg_path(t1, fill = "cyan", stroke = "black", stroke_width = 2, attrs = attrs) |>
+    svg_path(t2, fill = "orange", stroke = "black", stroke_width = 2, attrs = attrs) |>
+    as.character() |> cat()
 ```
 
 ## <a name="related">Related links</a>

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ remotes::install_github("trevorld/dee")
 
 ``` r
 library("dee", warn.conflicts = FALSE) # masks `stats::C()`
-library("omsvg")
 # https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d#example
 d <- M(10, 30) +
      A(20, 20, 0, 0, 1, 50, 30) +
@@ -48,14 +47,14 @@ print(d)
 
 
 ``` r
+library("omsvg")
 SVG(width = 100, height = 100, viewbox = TRUE) |>
-    svg_path(d, fill="red", stroke="black", stroke_width=2) |>
-    as.character() |> cat()
+    svg_path(d, fill="red", stroke="black", stroke_width=2)
 ```
 
-<svg width="100" height="100" viewBox="0 0 100 100">
+<!--html_preserve--><svg width="100" height="100" viewBox="0 0 100 100">
   <path d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 Z" stroke="black" stroke-width="2" fill="red"/>
-</svg>
+</svg><!--/html_preserve-->
 
 Instead of explicitly indicating each `x` and `y` coordinate one
 can also use objects that contain both `x` and `y` coordinates
@@ -65,7 +64,6 @@ if they can be coerced by `affiner::as_coord2d()`.
 ``` r
 library("affiner")
 library("dee", warn.conflicts = FALSE) # masks `stats::C()`
-library("omsvg")
 po <- as_coord2d(x = c(10, 10, 90, 90),
                  y = c(10, 90, 90, 10))
 pi <- po$clone()$
@@ -86,15 +84,15 @@ print(d)
 
 
 ``` r
+library("omsvg")
 attrs <- svg_attrs_pres(fill_rule = "evenodd")
 SVG(width = 100, height = 100, viewbox = TRUE) |>
-    svg_path(d, fill = "cyan", stroke = "black", stroke_width = 2, attrs = attrs) |>
-    as.character() |> cat()
+    svg_path(d, fill = "cyan", stroke = "black", stroke_width = 2, attrs = attrs)
 ```
 
-<svg width="100" height="100" viewBox="0 0 100 100">
+<!--html_preserve--><svg width="100" height="100" viewBox="0 0 100 100">
   <path d="M 10,10 10,90 90,90 90,10 Z M 50,22 22,50 50,78 78,50 Z" stroke="black" stroke-width="2" fill="cyan" fill-rule="evenodd"/>
-</svg>
+</svg><!--/html_preserve-->
 
 One can used the `dee.origin_at_bottom` and `dee.height` options if one
 prefers to think of the origin being at the bottom left corner (as is typical
@@ -104,7 +102,6 @@ with R graphics) instead of the top left corner (as is typical with the svg form
 ``` r
 library("affiner")
 library("dee", warn.conflicts = FALSE) # masks `stats::C()`
-library("omsvg")
 p <- as_coord2d(x = c(10, 40, 70),
                 y = c(10, 40, 10))
 t1 <- MZ(p)
@@ -128,17 +125,16 @@ print(t2)
 
 
 ``` r
-attrs <- svg_attrs_pres(fill_rule = "evenodd")
+library("omsvg")
 SVG(width = 100, height = 100, viewbox = TRUE) |>
-    svg_path(t1, fill = "cyan", stroke = "black", stroke_width = 2, attrs = attrs) |>
-    svg_path(t2, fill = "orange", stroke = "black", stroke_width = 2, attrs = attrs) |>
-    as.character() |> cat()
+    svg_path(t1, fill = "cyan", stroke = "black", stroke_width = 2) |>
+    svg_path(t2, fill = "orange", stroke = "black", stroke_width = 2)
 ```
 
-<svg width="100" height="100" viewBox="0 0 100 100">
-  <path d="M 10,10 40,40 70,10 Z" stroke="black" stroke-width="2" fill="cyan" fill-rule="evenodd"/>
-  <path d="M 10,90 40,60 70,90 Z" stroke="black" stroke-width="2" fill="orange" fill-rule="evenodd"/>
-</svg>
+<!--html_preserve--><svg width="100" height="100" viewBox="0 0 100 100">
+  <path d="M 10,10 40,40 70,10 Z" stroke="black" stroke-width="2" fill="cyan"/>
+  <path d="M 10,90 40,60 70,90 Z" stroke="black" stroke-width="2" fill="orange"/>
+</svg><!--/html_preserve-->
 
 ## <a name="related">Related links</a>
 

--- a/man/A.Rd
+++ b/man/A.Rd
@@ -15,7 +15,10 @@ A(
   sweep_flag = FALSE,
   x,
   y = NULL,
-  sep = getOption("dee.sep", ",")
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
 )
 
 aa(
@@ -26,7 +29,10 @@ aa(
   sweep_flag = FALSE,
   x,
   y = NULL,
-  sep = getOption("dee.sep", ",")
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
 )
 
 AZ(...)
@@ -49,13 +55,20 @@ Else a numeric vector.}
 
 \item{y}{Either \code{NULL} or a numeric vector.}
 
+\item{...}{Passed to related function.}
+
 \item{sep}{Either \code{","} or \code{" "}.}
 
-\item{...}{Passed to related function.}
+\item{origin_at_bottom, height}{If \code{origin_at_bottom} is \code{TRUE} then
+\code{y} (and any \code{y1} and \code{y2}) coordinates is transformed by \code{height - y}.}
 }
 \value{
 A \code{\link[=dee]{dee()}} object.
 }
 \description{
 \code{A()} and \code{aa()} draw elliptical arc curve commands.
+}
+\examples{
+M(1, 1) + A(rx = 1, x = 2, y = 2) + Z()
+M(1, 1) + aa(rx = 1, x = 1, y = 1) + zz()
 }

--- a/man/A.Rd
+++ b/man/A.Rd
@@ -42,13 +42,16 @@ az(...)
 \arguments{
 \item{rx, ry}{Radius of ellipse.}
 
-\item{x_axis_rotation}{Angle (in degrees) from x-axis of ellipse.}
+\item{x_axis_rotation}{Angle (in degrees) from x-axis of ellipse.
+Will be coerced by \code{\link[affiner:angle]{affiner::degrees()}}.
+If \code{isTRUE(origin_at_bottom)} will multiply by \code{-1}.}
 
 \item{large_arc_flag}{If \code{TRUE} then one of two larger arc sweeps chosen else
 one of the two smaller arc sweeps.}
 
 \item{sweep_flag}{If \code{TRUE} then arc will be drawn in "positive-angle" direction.
-else drawn in "negative-angle" direction.}
+else drawn in "negative-angle" direction.
+If \code{isTRUE(origin_at_bottom)} will invert.}
 
 \item{x}{If \code{y} is \code{NULL} will be coerced by \code{\link[affiner:as_coord2d]{affiner::as_coord2d()}}.
 Else a numeric vector.}

--- a/man/C.Rd
+++ b/man/C.Rd
@@ -11,17 +11,57 @@
 \alias{sz}
 \title{The cubic Bezier curve commands}
 \usage{
-C(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, sep = getOption("dee.sep", ","))
+C(
+  x1,
+  y1 = NULL,
+  x2,
+  y2 = NULL,
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
-cc(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, sep = getOption("dee.sep", ","))
+cc(
+  x1,
+  y1 = NULL,
+  x2,
+  y2 = NULL,
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
 CZ(...)
 
 cz(...)
 
-S(x2, y2 = NULL, x, y = NULL, sep = getOption("dee.sep", ","))
+S(
+  x2,
+  y2 = NULL,
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
-ss(x2, y2 = NULL, x, y = NULL, sep = getOption("dee.sep", ","))
+ss(
+  x2,
+  y2 = NULL,
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
 SZ(...)
 
@@ -43,9 +83,12 @@ Else a numeric vector.}
 
 \item{y}{Either \code{NULL} or a numeric vector.}
 
+\item{...}{Passed to related function.}
+
 \item{sep}{Either \code{","} or \code{" "}.}
 
-\item{...}{Passed to related function.}
+\item{origin_at_bottom, height}{If \code{origin_at_bottom} is \code{TRUE} then
+\code{y} (and any \code{y1} and \code{y2}) coordinates is transformed by \code{height - y}.}
 }
 \value{
 A \code{\link[=dee]{dee()}} object.
@@ -53,4 +96,8 @@ A \code{\link[=dee]{dee()}} object.
 \description{
 \code{C()} and \code{cc()} draw cubic Bezier curves
 \code{S()} and \code{ss()} draw cubic Bezier curves assuming the first control point is the reflection of the previous Bezier curve command.
+}
+\examples{
+M(1, 1) + C(2, 2, 3, 3, 4, 4) + Z()
+M(1, 1) + cc(1, 1, 2, 2, 3, 3) + zz()
 }

--- a/man/L.Rd
+++ b/man/L.Rd
@@ -15,9 +15,23 @@
 \alias{vz}
 \title{The "lineto" commands}
 \usage{
-L(x, y = NULL, sep = getOption("dee.sep", ","))
+L(
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
-ll(x, y = NULL, sep = getOption("dee.sep", ","))
+ll(
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
 LZ(...)
 
@@ -31,9 +45,19 @@ HZ(...)
 
 hz(...)
 
-V(y)
+V(
+  y,
+  ...,
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
-vv(y)
+vv(
+  y,
+  ...,
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
 VZ(...)
 
@@ -45,9 +69,12 @@ Else a numeric vector.}
 
 \item{y}{Either \code{NULL} or a numeric vector.}
 
+\item{...}{Passed to related function.}
+
 \item{sep}{Either \code{","} or \code{" "}.}
 
-\item{...}{Passed to related function.}
+\item{origin_at_bottom, height}{If \code{origin_at_bottom} is \code{TRUE} then
+\code{y} (and any \code{y1} and \code{y2}) coordinates is transformed by \code{height - y}.}
 }
 \value{
 A \code{\link[=dee]{dee()}} object.
@@ -56,4 +83,8 @@ A \code{\link[=dee]{dee()}} object.
 \code{L()} and \code{ll()} draw straight lines,
 \code{H()} and \code{hh()} draw horizontal lines, and
 \code{V()} and \code{vv()} draw vertical lines.
+}
+\examples{
+M(1, 1) + L(2, 2) + Z()
+M(1, 1) + ll(1, 1) + zz()
 }

--- a/man/M.Rd
+++ b/man/M.Rd
@@ -7,9 +7,23 @@
 \alias{mz}
 \title{The "moveto" commands}
 \usage{
-M(x, y = NULL, sep = getOption("dee.sep", ","))
+M(
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
-mm(x, y = NULL, sep = getOption("dee.sep", ","))
+mm(
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
 MZ(...)
 
@@ -21,13 +35,20 @@ Else a numeric vector.}
 
 \item{y}{Either \code{NULL} or a numeric vector.}
 
+\item{...}{Passed to related function.}
+
 \item{sep}{Either \code{","} or \code{" "}.}
 
-\item{...}{Passed to related function.}
+\item{origin_at_bottom, height}{If \code{origin_at_bottom} is \code{TRUE} then
+\code{y} (and any \code{y1} and \code{y2}) coordinates is transformed by \code{height - y}.}
 }
 \value{
 A \code{\link[=dee]{dee()}} object.
 }
 \description{
 \code{M()} and \code{mm()} move the "pen" to a new point.
+}
+\examples{
+M(1, 1) + L(2, 2) + Z()
+M(1, 1) + ll(1, 1) + zz()
 }

--- a/man/Q.Rd
+++ b/man/Q.Rd
@@ -11,17 +11,49 @@
 \alias{tz}
 \title{The quadratic Bezier curve commands}
 \usage{
-Q(x1, y1 = NULL, x, y = NULL, sep = getOption("dee.sep", ","))
+Q(
+  x1,
+  y1 = NULL,
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
-qq(x1, y1 = NULL, x, y = NULL, sep = getOption("dee.sep", ","))
+qq(
+  x1,
+  y1 = NULL,
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
 QZ(...)
 
 qz(...)
 
-T(x, y = NULL, sep = getOption("dee.sep", ","))
+T(
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
-tt(x, y = NULL, sep = getOption("dee.sep", ","))
+tt(
+  x,
+  y = NULL,
+  ...,
+  sep = getOption("dee.sep", ","),
+  origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
+  height = getOption("dee.height", NULL)
+)
 
 TZ(...)
 
@@ -38,9 +70,12 @@ Else a numeric vector.}
 
 \item{y}{Either \code{NULL} or a numeric vector.}
 
+\item{...}{Passed to related function.}
+
 \item{sep}{Either \code{","} or \code{" "}.}
 
-\item{...}{Passed to related function.}
+\item{origin_at_bottom, height}{If \code{origin_at_bottom} is \code{TRUE} then
+\code{y} (and any \code{y1} and \code{y2}) coordinates is transformed by \code{height - y}.}
 }
 \value{
 A \code{\link[=dee]{dee()}} object.
@@ -48,4 +83,8 @@ A \code{\link[=dee]{dee()}} object.
 \description{
 \code{Q()} and \code{qq()} draw quadratic Bezier curves
 \code{T()} and \code{tt()} draw quadratic Bezier curves assuming the control point is the reflection of the previous Bezier curve command.
+}
+\examples{
+M(1, 1) + Q(2, 2, 3, 3) + T(4, 4) + Z()
+M(1, 1) + qq(1, 1, 2, 2) + tt(1, 1) + zz()
 }

--- a/man/Z.Rd
+++ b/man/Z.Rd
@@ -15,3 +15,7 @@ A \code{\link[=dee]{dee()}} object.
 \description{
 \code{Z()} and \code{zz()} connects the initial point of the current subpath with the last point (with a straight line if these are different).  There is no difference between \code{Z()} and \code{zz()}.
 }
+\examples{
+M(1, 1) + L(2, 2) + Z()
+M(1, 1) + ll(2, 2) + zz()
+}

--- a/tests/testthat/test-path.r
+++ b/tests/testthat/test-path.r
@@ -1,11 +1,21 @@
 test_that("`M()`", {
+    do.call(rlang::local_options, default_options)
     expect_equal(MZ(1:2, 1:2) |> format(),
                  "M 1,1 2,2 Z")
     expect_equal(mz(1:2, 1:2) |> format(),
                  "m 1,1 2,2 z")
+
+    rlang::local_options(dee.origin_at_bottom = TRUE,
+                         dee.height = 10,
+                         dee.sep = " ")
+    expect_equal(MZ(1:2, 1:2) |> format(),
+                 "M 1 9 2 8 Z")
+    expect_equal(mz(1:2, 1:2) |> format(),
+                 "m 1 9 2 8 z")
 })
 
 test_that("`L()`", {
+    do.call(rlang::local_options, default_options)
     expect_equal(LZ(1:2, 1:2) |> format(),
                  "L 1,1 2,2 Z")
     expect_equal(lz(1:2, 1:2) |> format(),
@@ -23,6 +33,7 @@ test_that("`L()`", {
 })
 
 test_that("`Q()`", {
+    do.call(rlang::local_options, default_options)
     expect_equal(QZ(1:2, 1:2, 1:2, 1:2) |> format(),
                  "Q 1,1 1,1 2,2 2,2 Z")
     expect_equal(qz(1:2, 1:2, 1:2, 1:2) |> format(),
@@ -34,6 +45,7 @@ test_that("`Q()`", {
 })
 
 test_that("`C()`", {
+    do.call(rlang::local_options, default_options)
     expect_equal(CZ(1:2, 1:2, 1:2, 1:2, 1:2, 1:2) |> format(),
                  "C 1,1 1,1 1,1 2,2 2,2 2,2 Z")
     expect_equal(cz(1:2, 1:2, 1:2, 1:2, 1:2, 1:2) |> format(),
@@ -45,6 +57,7 @@ test_that("`C()`", {
 })
 
 test_that("`A()`", {
+    do.call(rlang::local_options, default_options)
     expect_equal(AZ(1:2, 1:2, 0, 0, 0, 1:2, 1:2) |> format(),
                  "A 1,1 0,0,0 1,1 2,2 0,0,0 2,2 Z")
     expect_equal(az(1:2, 1:2, 0, 0, 0, 1:2, 1:2) |> format(),


### PR DESCRIPTION
* Functions with `y` arguments now also support `origin_at_bottom` and `height` arguments.  If `isTRUE(origin_at_bottom)` then the `y` is transformed by `height - y`.
* These arguments have defaults `getOption("dee.origin_at_bottom",  FALSE)` and `getOption("dee.height", NULL)`.
* Also coerce `x_axis_rotation` with `affiner::degrees()`.