### PR TITLE
feat: `digits` argument and `dee.digits` option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dee
 Type: Package
 Title: 'd' Attribute Tools
-Version: 0.1.0-6
+Version: 0.1.0-7
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")))

--- a/R/dee-package.r
+++ b/R/dee-package.r
@@ -2,14 +2,15 @@
 #'  The following `dee` option may be set globally via [base::options()]:
 #'   \describe{
 #'     \item{dee.attrs}{[plot.dee()] passes this to [omsvg::svg_path()]'s `attrs` argument.}
-#'     \item{dee.height}{Passed to `height` arguments; the height of svg image (in pixels).}
-#'     \item{dee.width}{Passed to `width` arguments; the width of svg image (in pixels).}
 #'     \item{dee.background_color}{Passed to [plot.dee()]'s `background_color` argument.}
+#'     \item{dee.digits}{Passed to `digits` argument of svg d path command functions.}
 #'     \item{dee.fill}{[plot.dee()] passes this to [omsvg::svg_path()]'s `fill` argument.}
-#'     \item{dee.stroke}{[plot.dee()] passes this to [omsvg::svg_path()]'s `stroke` argument.}
-#'     \item{dee.stroke_width}{[plot.dee()] passes this to [omsvg::svg_path()]'s `stroke_width` argument.}
+#'     \item{dee.height}{Passed to `height` arguments; the height of svg image (in pixels).}
 #'     \item{dee.origin_at_bottom}{Passed to `origin_at_bottom` argument of svg d path command functions.}
 #'     \item{dee.sep}{Passed to `sep` argument of svg d path command functions.}
+#'     \item{dee.stroke}{[plot.dee()] passes this to [omsvg::svg_path()]'s `stroke` argument.}
+#'     \item{dee.stroke_width}{[plot.dee()] passes this to [omsvg::svg_path()]'s `stroke_width` argument.}
+#'     \item{dee.width}{Passed to `width` arguments; the width of svg image (in pixels).}
 #'   }
 #' @keywords internal
 "_PACKAGE"

--- a/R/dee_options.r
+++ b/R/dee_options.r
@@ -22,14 +22,15 @@ default_options <- list(dee.sep = ",",
 #' @export
 dee_options <- function (..., default = FALSE) {
     dee_op <- list(dee.attrs = NULL,
-                   dee.height = NULL,
-                   dee.width = NULL,
                    dee.background_color = NULL,
+                   dee.digits = Inf,
                    dee.fill = NULL,
+                   dee.height = NULL,
+                   dee.origin_at_bottom = FALSE,
+                   dee.sep = ",",
                    dee.stroke = NULL,
                    dee.stroke_width = NULL,
-                   dee.origin_at_bottom = FALSE,
-                   dee.sep = ",")
+                   dee.width = NULL)
     l <- list(...)
     stopifnot(all(names(l) %in% names(dee_op)))
     if (isFALSE(default)) {

--- a/R/path.r
+++ b/R/path.r
@@ -24,6 +24,8 @@ zz <- function() dee("z")
 #' @param origin_at_bottom,height If `origin_at_bottom` is `TRUE` then
 #'                                `y` (and any `y1` and `y2`) coordinates is transformed by
 #'                                `height - y` for absolute coordinates and `-y` for relative coordinates.
+#' @param digits `x` and `y` (and any `x1`, `y1`, `x2`, `y2`) will be transformed by `round(, digits)`.
+#'               An `Inf` (default) means no rounding.
 #' @return A [dee()] object.
 #' @examples
 #' M(1, 1) + L(2, 2) + Z()
@@ -32,7 +34,8 @@ zz <- function() dee("z")
 M <- function(x, y = NULL, ...,
               sep = getOption("dee.sep", ","),
               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-              height = getOption("dee.height", NULL)) {
+              height = getOption("dee.height", NULL),
+              digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
@@ -40,6 +43,8 @@ M <- function(x, y = NULL, ...,
     if (isTRUE(origin_at_bottom)) {
         y <- height - y
     }
+    x <- round(x, digits)
+    y <- round(y, digits)
     paste(c("M", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
@@ -48,7 +53,8 @@ M <- function(x, y = NULL, ...,
 mm <- function(x, y = NULL, ...,
                sep = getOption("dee.sep", ","),
                origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-               height = getOption("dee.height", NULL)) {
+               height = getOption("dee.height", NULL),
+               digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
@@ -56,6 +62,8 @@ mm <- function(x, y = NULL, ...,
     if (isTRUE(origin_at_bottom)) {
         y <- -y
     }
+    x <- round(x, digits)
+    y <- round(y, digits)
     paste(c("m", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
@@ -88,7 +96,8 @@ mz <- function(...) {
 L <- function(x, y = NULL, ...,
               sep = getOption("dee.sep", ","),
               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-              height = getOption("dee.height", NULL)) {
+              height = getOption("dee.height", NULL),
+              digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
@@ -96,6 +105,8 @@ L <- function(x, y = NULL, ...,
     if (isTRUE(origin_at_bottom)) {
         y <- height - y
     }
+    x <- round(x, digits)
+    y <- round(y, digits)
     paste(c("L", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
@@ -104,7 +115,8 @@ L <- function(x, y = NULL, ...,
 ll <- function(x, y = NULL, ...,
                sep = getOption("dee.sep", ","),
                origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-               height = getOption("dee.height", NULL)) {
+               height = getOption("dee.height", NULL),
+               digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
@@ -112,6 +124,8 @@ ll <- function(x, y = NULL, ...,
     if (isTRUE(origin_at_bottom)) {
         y <- -y
     }
+    x <- round(x, digits)
+    y <- round(y, digits)
     paste(c("l", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
@@ -129,15 +143,19 @@ lz <- function(...) {
 
 #' @rdname L
 #' @export
-H <- function(x) {
+H <- function(x, ..., digits = getOption("dee.digits", Inf)) {
+    check_dots_empty()
     stopifnot(is.numeric(x))
+    x <- round(x, digits)
     paste(c("H", x), collapse = " ") |> dee()
 }
 
 #' @rdname L
 #' @export
-hh <- function(x) {
+hh <- function(x, ..., digits = getOption("dee.digits", Inf)) {
+    check_dots_empty()
     stopifnot(is.numeric(x))
+    x <- round(x, digits)
     paste(c("h", x), collapse = " ") |> dee()
 }
 
@@ -157,12 +175,14 @@ hz <- function(...) {
 #' @export
 V <- function(y, ...,
               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-              height = getOption("dee.height", NULL)) {
+              height = getOption("dee.height", NULL),
+              digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     stopifnot(is.numeric(y))
     if (isTRUE(origin_at_bottom)) {
         y <- height - y
     }
+    y <- round(y, digits)
     paste(c("V", y), collapse = " ") |> dee()
 }
 
@@ -170,12 +190,14 @@ V <- function(y, ...,
 #' @export
 vv <- function(y, ...,
                origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-               height = getOption("dee.height", NULL)) {
+               height = getOption("dee.height", NULL),
+               digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     stopifnot(is.numeric(y))
     if (isTRUE(origin_at_bottom)) {
         y <- -y
     }
+    y <- round(y, digits)
     paste(c("v", y), collapse = " ") |> dee()
 }
 
@@ -209,7 +231,8 @@ vz <- function(...) {
 Q <- function(x1, y1 = NULL, x, y = NULL, ...,
               sep = getOption("dee.sep", ","),
               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-              height = getOption("dee.height", NULL)) {
+              height = getOption("dee.height", NULL),
+              digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p1 <- as_coords(x1, y1)
     p <- as_coords(x, y)
@@ -221,6 +244,10 @@ Q <- function(x1, y1 = NULL, x, y = NULL, ...,
         y1 <- height - y1
         y <- height - y
     }
+    x1 <- round(x1, digits)
+    y1 <- round(y1, digits)
+    x <- round(x, digits)
+    y <- round(y, digits)
     xy1 <- paste(x1, y1, sep = sep)
     xy <- paste(x, y, sep = sep)
     paste(c("Q", paste(xy1, xy)), collapse = " ") |> dee()
@@ -231,7 +258,8 @@ Q <- function(x1, y1 = NULL, x, y = NULL, ...,
 qq <- function(x1, y1 = NULL, x, y = NULL, ...,
                sep = getOption("dee.sep", ","),
                origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-               height = getOption("dee.height", NULL)) {
+               height = getOption("dee.height", NULL),
+               digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p1 <- as_coords(x1, y1)
     p <- as_coords(x, y)
@@ -243,6 +271,10 @@ qq <- function(x1, y1 = NULL, x, y = NULL, ...,
         y1 <- -y1
         y <- -y
     }
+    x1 <- round(x1, digits)
+    y1 <- round(y1, digits)
+    x <- round(x, digits)
+    y <- round(y, digits)
     xy1 <- paste(x1, y1, sep = sep)
     xy <- paste(x, y, sep = sep)
     paste(c("q", paste(xy1, xy)), collapse = " ") |> dee()
@@ -265,7 +297,8 @@ qz <- function(...) {
 T <- function(x, y = NULL, ...,
               sep = getOption("dee.sep", ","),
               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-              height = getOption("dee.height", NULL)) {
+              height = getOption("dee.height", NULL),
+              digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
@@ -273,6 +306,8 @@ T <- function(x, y = NULL, ...,
     if (isTRUE(origin_at_bottom)) {
         y <- height - y
     }
+    x <- round(x, digits)
+    y <- round(y, digits)
     paste(c("T", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
@@ -281,7 +316,8 @@ T <- function(x, y = NULL, ...,
 tt <- function(x, y = NULL, ...,
                sep = getOption("dee.sep", ","),
                origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-               height = getOption("dee.height", NULL)) {
+               height = getOption("dee.height", NULL),
+               digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p <- as_coords(x, y)
     x <- p$x
@@ -289,6 +325,8 @@ tt <- function(x, y = NULL, ...,
     if (isTRUE(origin_at_bottom)) {
         y <- -y
     }
+    x <- round(x, digits)
+    y <- round(y, digits)
     paste(c("t", paste(x, y, sep = sep)), collapse = " ") |> dee()
 }
 
@@ -322,7 +360,8 @@ tz <- function(...) {
 C <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, ...,
               sep = getOption("dee.sep", ","),
               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-              height = getOption("dee.height", NULL)) {
+              height = getOption("dee.height", NULL),
+              digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p1 <- as_coords(x1, y1)
     p2 <- as_coords(x2, y2)
@@ -338,6 +377,12 @@ C <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, ...,
         y1 <- height - y1
         y <- height - y
     }
+    x1 <- round(x1, digits)
+    y1 <- round(y1, digits)
+    x2 <- round(x2, digits)
+    y2 <- round(y2, digits)
+    x <- round(x, digits)
+    y <- round(y, digits)
     xy1 <- paste(x1, y1, sep = sep)
     xy2 <- paste(x2, y2, sep = sep)
     xy <- paste(x, y, sep = sep)
@@ -349,7 +394,8 @@ C <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL, ...,
 cc <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL,...,
                sep = getOption("dee.sep", ","),
                origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-               height = getOption("dee.height", NULL)) {
+               height = getOption("dee.height", NULL),
+               digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p1 <- as_coords(x1, y1)
     p2 <- as_coords(x2, y2)
@@ -365,6 +411,12 @@ cc <- function(x1, y1 = NULL, x2, y2 = NULL, x, y = NULL,...,
         y1 <- -y1
         y <- -y
     }
+    x2 <- round(x2, digits)
+    y2 <- round(y2, digits)
+    x1 <- round(x1, digits)
+    y1 <- round(y1, digits)
+    x <- round(x, digits)
+    y <- round(y, digits)
     xy1 <- paste(x1, y1, sep = sep)
     xy2 <- paste(x2, y2, sep = sep)
     xy <- paste(x, y, sep = sep)
@@ -388,7 +440,8 @@ cz <- function(...) {
 S <- function(x2, y2 = NULL, x, y = NULL,...,
               sep = getOption("dee.sep", ","),
               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-              height = getOption("dee.height", NULL)) {
+              height = getOption("dee.height", NULL),
+              digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p2 <- as_coords(x2, y2)
     p <- as_coords(x, y)
@@ -400,6 +453,10 @@ S <- function(x2, y2 = NULL, x, y = NULL,...,
         y2 <- height - y2
         y <- height - y
     }
+    x2 <- round(x2, digits)
+    y2 <- round(y2, digits)
+    x <- round(x, digits)
+    y <- round(y, digits)
     xy2 <- paste(x2, y2, sep = sep)
     xy <- paste(x, y, sep = sep)
     paste(c("S", paste(xy2, xy)), collapse = " ") |> dee()
@@ -410,7 +467,8 @@ S <- function(x2, y2 = NULL, x, y = NULL,...,
 ss <- function(x2, y2 = NULL, x, y = NULL, ...,
                sep = getOption("dee.sep", ","),
                origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-               height = getOption("dee.height", NULL)) {
+               height = getOption("dee.height", NULL),
+               digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     p2 <- as_coords(x2, y2)
     p <- as_coords(x, y)
@@ -422,6 +480,10 @@ ss <- function(x2, y2 = NULL, x, y = NULL, ...,
         y2 <- -y2
         y <- -y
     }
+    x2 <- round(x2, digits)
+    y2 <- round(y2, digits)
+    x <- round(x, digits)
+    y <- round(y, digits)
     xy2 <- paste(x2, y2, sep = sep)
     xy <- paste(x, y, sep = sep)
     paste(c("s", paste(xy2, xy)), collapse = " ") |> dee()
@@ -464,7 +526,8 @@ A <- function(rx, ry = rx,
               x, y = NULL, ...,
               sep = getOption("dee.sep", ","),
               origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-              height = getOption("dee.height", NULL)) {
+              height = getOption("dee.height", NULL),
+              digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     stopifnot(is.numeric(rx), is.numeric(rx))
     rxy <- paste(rx, ry, sep = sep)
@@ -484,6 +547,8 @@ A <- function(rx, ry = rx,
     if (isTRUE(origin_at_bottom)) {
         y <- height - y
     }
+    x <- round(x, digits)
+    y <- round(y, digits)
     xy <- paste(x, y, sep = sep)
     paste(c("A", paste(rxy, rls, xy)), collapse = " ") |> dee()
 }
@@ -493,7 +558,8 @@ A <- function(rx, ry = rx,
 aa <- function(rx, ry = rx, x_axis_rotation = 0, large_arc_flag = FALSE, sweep_flag = FALSE, x, y = NULL,...,
                sep = getOption("dee.sep", ","),
                origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-               height = getOption("dee.height", NULL)) {
+               height = getOption("dee.height", NULL),
+               digits = getOption("dee.digits", Inf)) {
     check_dots_empty()
     stopifnot(is.numeric(rx), is.numeric(rx))
     rxy <- paste(rx, ry, sep = sep)
@@ -512,6 +578,8 @@ aa <- function(rx, ry = rx, x_axis_rotation = 0, large_arc_flag = FALSE, sweep_f
     if (isTRUE(origin_at_bottom)) {
         y <- -y
     }
+    x <- round(x, digits)
+    y <- round(y, digits)
     xy <- paste(x, y, sep = sep)
     paste(c("a", paste(rxy, rls, xy)), collapse = " ") |> dee()
 }

--- a/man/A.Rd
+++ b/man/A.Rd
@@ -18,7 +18,8 @@ A(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 aa(
@@ -32,7 +33,8 @@ aa(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 AZ(...)
@@ -65,6 +67,9 @@ Else a numeric vector.}
 \item{origin_at_bottom, height}{If \code{origin_at_bottom} is \code{TRUE} then
 \code{y} (and any \code{y1} and \code{y2}) coordinates is transformed by
 \code{height - y} for absolute coordinates and \code{-y} for relative coordinates.}
+
+\item{digits}{\code{x} and \code{y} (and any \code{x1}, \code{y1}, \code{x2}, \code{y2}) will be transformed by \code{round(, digits)}.
+An \code{Inf} (default) means no rounding.}
 }
 \value{
 A \code{\link[=dee]{dee()}} object.

--- a/man/C.Rd
+++ b/man/C.Rd
@@ -21,7 +21,8 @@ C(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 cc(
@@ -34,7 +35,8 @@ cc(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 CZ(...)
@@ -49,7 +51,8 @@ S(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 ss(
@@ -60,7 +63,8 @@ ss(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 SZ(...)
@@ -90,6 +94,9 @@ Else a numeric vector.}
 \item{origin_at_bottom, height}{If \code{origin_at_bottom} is \code{TRUE} then
 \code{y} (and any \code{y1} and \code{y2}) coordinates is transformed by
 \code{height - y} for absolute coordinates and \code{-y} for relative coordinates.}
+
+\item{digits}{\code{x} and \code{y} (and any \code{x1}, \code{y1}, \code{x2}, \code{y2}) will be transformed by \code{round(, digits)}.
+An \code{Inf} (default) means no rounding.}
 }
 \value{
 A \code{\link[=dee]{dee()}} object.

--- a/man/L.Rd
+++ b/man/L.Rd
@@ -21,7 +21,8 @@ L(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 ll(
@@ -30,16 +31,17 @@ ll(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 LZ(...)
 
 lz(...)
 
-H(x)
+H(x, ..., digits = getOption("dee.digits", Inf))
 
-hh(x)
+hh(x, ..., digits = getOption("dee.digits", Inf))
 
 HZ(...)
 
@@ -49,14 +51,16 @@ V(
   y,
   ...,
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 vv(
   y,
   ...,
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 VZ(...)
@@ -76,6 +80,9 @@ Else a numeric vector.}
 \item{origin_at_bottom, height}{If \code{origin_at_bottom} is \code{TRUE} then
 \code{y} (and any \code{y1} and \code{y2}) coordinates is transformed by
 \code{height - y} for absolute coordinates and \code{-y} for relative coordinates.}
+
+\item{digits}{\code{x} and \code{y} (and any \code{x1}, \code{y1}, \code{x2}, \code{y2}) will be transformed by \code{round(, digits)}.
+An \code{Inf} (default) means no rounding.}
 }
 \value{
 A \code{\link[=dee]{dee()}} object.

--- a/man/M.Rd
+++ b/man/M.Rd
@@ -13,7 +13,8 @@ M(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 mm(
@@ -22,7 +23,8 @@ mm(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 MZ(...)
@@ -42,6 +44,9 @@ Else a numeric vector.}
 \item{origin_at_bottom, height}{If \code{origin_at_bottom} is \code{TRUE} then
 \code{y} (and any \code{y1} and \code{y2}) coordinates is transformed by
 \code{height - y} for absolute coordinates and \code{-y} for relative coordinates.}
+
+\item{digits}{\code{x} and \code{y} (and any \code{x1}, \code{y1}, \code{x2}, \code{y2}) will be transformed by \code{round(, digits)}.
+An \code{Inf} (default) means no rounding.}
 }
 \value{
 A \code{\link[=dee]{dee()}} object.

--- a/man/Q.Rd
+++ b/man/Q.Rd
@@ -19,7 +19,8 @@ Q(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 qq(
@@ -30,7 +31,8 @@ qq(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 QZ(...)
@@ -43,7 +45,8 @@ T(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 tt(
@@ -52,7 +55,8 @@ tt(
   ...,
   sep = getOption("dee.sep", ","),
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
-  height = getOption("dee.height", NULL)
+  height = getOption("dee.height", NULL),
+  digits = getOption("dee.digits", Inf)
 )
 
 TZ(...)
@@ -77,6 +81,9 @@ Else a numeric vector.}
 \item{origin_at_bottom, height}{If \code{origin_at_bottom} is \code{TRUE} then
 \code{y} (and any \code{y1} and \code{y2}) coordinates is transformed by
 \code{height - y} for absolute coordinates and \code{-y} for relative coordinates.}
+
+\item{digits}{\code{x} and \code{y} (and any \code{x1}, \code{y1}, \code{x2}, \code{y2}) will be transformed by \code{round(, digits)}.
+An \code{Inf} (default) means no rounding.}
 }
 \value{
 A \code{\link[=dee]{dee()}} object.

--- a/man/dee-package.Rd
+++ b/man/dee-package.Rd
@@ -12,14 +12,15 @@ Utilities to build an svg path 'd' \url{https://developer.mozilla.org/en-US/docs
 The following \code{dee} option may be set globally via \code{\link[base:options]{base::options()}}:
 \describe{
 \item{dee.attrs}{\code{\link[=plot.dee]{plot.dee()}} passes this to \code{\link[omsvg:svg_path]{omsvg::svg_path()}}'s \code{attrs} argument.}
-\item{dee.height}{Passed to \code{height} arguments; the height of svg image (in pixels).}
-\item{dee.width}{Passed to \code{width} arguments; the width of svg image (in pixels).}
 \item{dee.background_color}{Passed to \code{\link[=plot.dee]{plot.dee()}}'s \code{background_color} argument.}
+\item{dee.digits}{Passed to \code{digits} argument of svg d path command functions.}
 \item{dee.fill}{\code{\link[=plot.dee]{plot.dee()}} passes this to \code{\link[omsvg:svg_path]{omsvg::svg_path()}}'s \code{fill} argument.}
-\item{dee.stroke}{\code{\link[=plot.dee]{plot.dee()}} passes this to \code{\link[omsvg:svg_path]{omsvg::svg_path()}}'s \code{stroke} argument.}
-\item{dee.stroke_width}{\code{\link[=plot.dee]{plot.dee()}} passes this to \code{\link[omsvg:svg_path]{omsvg::svg_path()}}'s \code{stroke_width} argument.}
+\item{dee.height}{Passed to \code{height} arguments; the height of svg image (in pixels).}
 \item{dee.origin_at_bottom}{Passed to \code{origin_at_bottom} argument of svg d path command functions.}
 \item{dee.sep}{Passed to \code{sep} argument of svg d path command functions.}
+\item{dee.stroke}{\code{\link[=plot.dee]{plot.dee()}} passes this to \code{\link[omsvg:svg_path]{omsvg::svg_path()}}'s \code{stroke} argument.}
+\item{dee.stroke_width}{\code{\link[=plot.dee]{plot.dee()}} passes this to \code{\link[omsvg:svg_path]{omsvg::svg_path()}}'s \code{stroke_width} argument.}
+\item{dee.width}{Passed to \code{width} arguments; the width of svg image (in pixels).}
 }
 }
 

--- a/tests/testthat/test-path.r
+++ b/tests/testthat/test-path.r
@@ -17,6 +17,12 @@ test_that("`M()`", {
                  "m 1 -1 2 -2 z")
     expect_equal(MZ(p) |> format(),
                  "M 1 7 2 6 Z")
+
+    expect_equal(M(1.25, 1.75) |> format(),
+                 "M 1.25 8.25")
+    rlang::local_options(dee.digits = 0)
+    expect_equal(M(1.25, 1.75) |> format(),
+                 "M 1 8")
 })
 
 test_that("`L()`", {


### PR DESCRIPTION
* New `digits` argument to svg path functions which round (x,y) coordinates with `round(, digits)`. Defaults to `getOption("dee.digits", Inf)` (i.e. no rounding).

closes #4