### PR TITLE
feat!: Add `alpha`, `beta_ext`, `d` shortcuts to `d_isotoxal_2ngon()`, move `s` after `...`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dee
 Type: Package
 Title: 'd' Attribute Tools
-Version: 0.1.0-26
+Version: 0.1.0-27
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")))
@@ -11,7 +11,7 @@ Description: Utilities to build an svg path 'd' <https://developer.mozilla.org/e
 Depends:
     R (>= 4.2)
 Imports:
-	affiner (>= 0.2.0),
+	affiner (>= 0.3.1),
 	grid,
 	rlang,
 	utils

--- a/R/isotoxal_2ngon.R
+++ b/R/isotoxal_2ngon.R
@@ -2,49 +2,60 @@
 #'
 #' `d_isotoxal_2ngon()` is a wrapper around `d_polygon()`
 #' to create isotoxal `2n`-gon polygon shaped paths.
-#' Its vectorized in its `x`, `y`, `r`, `s`, `n`, `a`, and `offset` arguments.
+#' Its vectorized in its `x`, `y`, `r`, `n`, `a`, `s`, and `offset` arguments.
 #' `d_star()` is provided as an alias.
 #'
 #' @inheritParams d_polygon
 #' @inheritParams M
 #' @param r The outer radius of the isotoxal `2n`-gon polygon.
-#' @param s The inner radius of the isotoxal `2n`-gon polygon as a **fraction** of the outer radius i.e. the inner radius = `s * r`.  [affiner::isotoxal_2ngon_inner_radius()] may be of help computing this.
+#' @param s The inner radius of the isotoxal `2n`-gon polygon as a
+#'   **fraction** of the outer radius i.e. the inner radius = `s * r`.
+#'   Defaults to [affiner::isotoxal_2ngon_inner_radius()] computed from
+#'   exactly one of `alpha`, `beta_ext`, or `d`.
 #' @param n The number of outer vertices.
-#' @param a The angle of the first outer vertex (will be coerced by [affiner::degrees()]).
+#' @param a The angle of the first outer vertex (will be coerced by
+#'   [affiner::degrees()]).
 #' @param ... Passed to [d_polygon()].
-#' @seealso [d_polygon()] and [d_regular_ngon()].  See <https://en.wikipedia.org/wiki/Isotoxal_figure#Isotoxal_polygons> and <https://en.wikipedia.org/wiki/Star_polygon#Isotoxal_star_simple_polygons> for more information on isotoxal polygons.
+#' @param alpha Interior angle of an outer vertex passed to
+#'   [affiner::isotoxal_2ngon_inner_radius()] to compute `s`.
+#'   Will be coerced by [affiner::degrees()].
+#' @param beta_ext Exterior angle of an inner vertex passed to
+#'   [affiner::isotoxal_2ngon_inner_radius()] to compute `s`.
+#'   Will be coerced by [affiner::degrees()].
+#' @param d Density (winding number) of the star polygon `|n/d|` passed to
+#'   [affiner::isotoxal_2ngon_inner_radius()] to compute `s`.
+#' @seealso [d_polygon()] and [d_regular_ngon()].  See
+#'   <https://en.wikipedia.org/wiki/Isotoxal_figure#Isotoxal_polygons> and
+#'   <https://en.wikipedia.org/wiki/Star_polygon#Isotoxal_star_simple_polygons>
+#'   for more information on isotoxal polygons.
 #' @return A [dee()] object.
 #' @examples
-#' # A |5/2| star e.g. the *verda stelo*
-#' s <- affiner::isotoxal_2ngon_inner_radius(n = 5, d = 2)
-#' d <- d_isotoxal_2ngon(x = 5, y = 5, r = 3, s = s, n = 5)
+#' # A |5/2| star e.g. the *verda stelo* (using `d` shortcut)
+#' d <- d_isotoxal_2ngon(x = 5, y = 5, r = 3, n = 5, d = 2)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
 #'     requireNamespace("svgparser", quietly = TRUE)) {
 #'   plot(d, height = 10, width = 10,
 #'        fill = "green", stroke = "none")
 #' }
-#' # "lozenge" shape most often has acute angles of 45 degrees
-#' s <- affiner::isotoxal_2ngon_inner_radius(n = 2, alpha = 45)
-#' d <- d_isotoxal_2ngon(x = 5, y = 5, r = 4, s = s, n = 2)
+#' # "lozenge" shape most often has acute angles of 45 degrees (using `alpha`)
+#' d <- d_isotoxal_2ngon(x = 5, y = 5, r = 4, n = 2, alpha = 45)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
 #'     requireNamespace("svgparser", quietly = TRUE)) {
 #'   plot(d, height = 10, width = 10,
 #'        fill = "cyan", stroke = "black", stroke_width = 4)
 #' }
 #' # `d_star()` is an alias for `d_isotoxal_2ngon()`
-#' # Inner exterior angle of |8/3| star is 90 degrees
-#' s <- affiner::isotoxal_2ngon_inner_radius(n = 8, beta_ext = 90)
-#' d <- d_star(x = 5, y = 5, r = 4, s = s, n = 8, a = 22.5)
+#' # Inner exterior angle of |8/3| star is 90 degrees (using `beta_ext`)
+#' d <- d_star(x = 5, y = 5, r = 4, n = 8, a = 22.5, beta_ext = 90)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
 #'     requireNamespace("svgparser", quietly = TRUE)) {
 #'   plot(d, height = 10, width = 10,
 #'        fill = "yellow", stroke = "black", stroke_width = 4)
 #' }
 #'
-#' # Degenerate case of inner vertex with exterior angle
-#' # of 180 degrees creates a regular `n`-gon.
-#' s <- affiner::isotoxal_2ngon_inner_radius(n = 8, beta_ext = 180)
-#' d <- d_star(x = 5, y = 5, r = 4, s = s, n = 8, a = 22.5)
+#' # Degenerate case of inner vertex with exterior angle of 180 degrees
+#' # creates a regular `n`-gon.
+#' d <- d_star(x = 5, y = 5, r = 4, n = 8, a = 22.5, beta_ext = 180)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
 #'     requireNamespace("svgparser", quietly = TRUE)) {
 #'   plot(d, height = 10, width = 10,
@@ -55,10 +66,13 @@ d_isotoxal_2ngon <- function(
 	x,
 	y,
 	r,
-	s,
 	n,
 	a = 90,
 	...,
+	s = affiner::isotoxal_2ngon_inner_radius(n, alpha = alpha, beta_ext = beta_ext, d = d),
+	alpha = NULL,
+	beta_ext = NULL,
+	d = NULL,
 	offset = 0,
 	origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
 	height = getOption("dee.height")
@@ -68,7 +82,20 @@ d_isotoxal_2ngon <- function(
 	y <- p$y
 	if (isTRUE(origin_at_bottom)) {
 		y <- height - y
-		return(d_isotoxal_2ngon(x, y, r, s, n, a, ..., offset = offset, origin_at_bottom = FALSE))
+		return(d_isotoxal_2ngon(
+			x,
+			y,
+			r,
+			n,
+			a,
+			...,
+			s = s,
+			alpha = alpha,
+			beta_ext = beta_ext,
+			d = d,
+			offset = offset,
+			origin_at_bottom = FALSE
+		))
 	}
 	r <- as.numeric(r)
 	s <- as.numeric(s)

--- a/README.Rmd
+++ b/README.Rmd
@@ -108,7 +108,7 @@ We also contain vectorized convenience wrappers for some common shapes:
 s <- 0.6
 ro <- 50
 ri <- s * ro
-d <- d_circle(50, 50, c(ro, ri, ri - 3)) + d_star(50, 50, ro, s, 8, digits = 0)
+d <- d_circle(50, 50, c(ro, ri, ri - 3)) + d_star(50, 50, ro, 8, s = s, digits = 0)
 print(d)
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ We also contain vectorized convenience wrappers for some common shapes:
 s <- 0.6
 ro <- 50
 ri <- s * ro
-d <- d_circle(50, 50, c(ro, ri, ri - 3)) + d_star(50, 50, ro, s, 8, digits = 0)
+d <- d_circle(50, 50, c(ro, ri, ri - 3)) + d_star(50, 50, ro, 8, s = s, digits = 0)
 print(d)
 ```
 

--- a/man/d_isotoxal_2ngon.Rd
+++ b/man/d_isotoxal_2ngon.Rd
@@ -9,10 +9,13 @@ d_isotoxal_2ngon(
   x,
   y,
   r,
-  s,
   n,
   a = 90,
   ...,
+  s = affiner::isotoxal_2ngon_inner_radius(n, alpha = alpha, beta_ext = beta_ext, d = d),
+  alpha = NULL,
+  beta_ext = NULL,
+  d = NULL,
   offset = 0,
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
   height = getOption("dee.height")
@@ -22,10 +25,13 @@ d_star(
   x,
   y,
   r,
-  s,
   n,
   a = 90,
   ...,
+  s = affiner::isotoxal_2ngon_inner_radius(n, alpha = alpha, beta_ext = beta_ext, d = d),
+  alpha = NULL,
+  beta_ext = NULL,
+  d = NULL,
   offset = 0,
   origin_at_bottom = getOption("dee.origin_at_bottom", FALSE),
   height = getOption("dee.height")
@@ -39,13 +45,28 @@ Else a numeric vector.}
 
 \item{r}{The outer radius of the isotoxal \verb{2n}-gon polygon.}
 
-\item{s}{The inner radius of the isotoxal \verb{2n}-gon polygon as a \strong{fraction} of the outer radius i.e. the inner radius = \code{s * r}.  \code{\link[affiner:isotoxal_2ngon_inner_radius]{affiner::isotoxal_2ngon_inner_radius()}} may be of help computing this.}
-
 \item{n}{The number of outer vertices.}
 
-\item{a}{The angle of the first outer vertex (will be coerced by \code{\link[affiner:degrees]{affiner::degrees()}}).}
+\item{a}{The angle of the first outer vertex (will be coerced by
+\code{\link[affiner:degrees]{affiner::degrees()}}).}
 
 \item{...}{Passed to \code{\link[=d_polygon]{d_polygon()}}.}
+
+\item{s}{The inner radius of the isotoxal \verb{2n}-gon polygon as a
+\strong{fraction} of the outer radius i.e. the inner radius = \code{s * r}.
+Defaults to \code{\link[affiner:isotoxal_2ngon_inner_radius]{affiner::isotoxal_2ngon_inner_radius()}} computed from
+exactly one of \code{alpha}, \code{beta_ext}, or \code{d}.}
+
+\item{alpha}{Interior angle of an outer vertex passed to
+\code{\link[affiner:isotoxal_2ngon_inner_radius]{affiner::isotoxal_2ngon_inner_radius()}} to compute \code{s}.
+Will be coerced by \code{\link[affiner:degrees]{affiner::degrees()}}.}
+
+\item{beta_ext}{Exterior angle of an inner vertex passed to
+\code{\link[affiner:isotoxal_2ngon_inner_radius]{affiner::isotoxal_2ngon_inner_radius()}} to compute \code{s}.
+Will be coerced by \code{\link[affiner:degrees]{affiner::degrees()}}.}
+
+\item{d}{Density (winding number) of the star polygon \verb{|n/d|} passed to
+\code{\link[affiner:isotoxal_2ngon_inner_radius]{affiner::isotoxal_2ngon_inner_radius()}} to compute \code{s}.}
 
 \item{offset}{If a positive number the distance for \emph{outward} polygon offsetting.  If a negative number the distance for \emph{inward} polygon offsetting.}
 
@@ -59,40 +80,36 @@ A \code{\link[=dee]{dee()}} object.
 \description{
 \code{d_isotoxal_2ngon()} is a wrapper around \code{d_polygon()}
 to create isotoxal \verb{2n}-gon polygon shaped paths.
-Its vectorized in its \code{x}, \code{y}, \code{r}, \code{s}, \code{n}, \code{a}, and \code{offset} arguments.
+Its vectorized in its \code{x}, \code{y}, \code{r}, \code{n}, \code{a}, \code{s}, and \code{offset} arguments.
 \code{d_star()} is provided as an alias.
 }
 \examples{
-# A |5/2| star e.g. the *verda stelo*
-s <- affiner::isotoxal_2ngon_inner_radius(n = 5, d = 2)
-d <- d_isotoxal_2ngon(x = 5, y = 5, r = 3, s = s, n = 5)
+# A |5/2| star e.g. the *verda stelo* (using `d` shortcut)
+d <- d_isotoxal_2ngon(x = 5, y = 5, r = 3, n = 5, d = 2)
 if (requireNamespace("omsvg", quietly = TRUE) &&
     requireNamespace("svgparser", quietly = TRUE)) {
   plot(d, height = 10, width = 10,
        fill = "green", stroke = "none")
 }
-# "lozenge" shape most often has acute angles of 45 degrees
-s <- affiner::isotoxal_2ngon_inner_radius(n = 2, alpha = 45)
-d <- d_isotoxal_2ngon(x = 5, y = 5, r = 4, s = s, n = 2)
+# "lozenge" shape most often has acute angles of 45 degrees (using `alpha`)
+d <- d_isotoxal_2ngon(x = 5, y = 5, r = 4, n = 2, alpha = 45)
 if (requireNamespace("omsvg", quietly = TRUE) &&
     requireNamespace("svgparser", quietly = TRUE)) {
   plot(d, height = 10, width = 10,
        fill = "cyan", stroke = "black", stroke_width = 4)
 }
 # `d_star()` is an alias for `d_isotoxal_2ngon()`
-# Inner exterior angle of |8/3| star is 90 degrees
-s <- affiner::isotoxal_2ngon_inner_radius(n = 8, beta_ext = 90)
-d <- d_star(x = 5, y = 5, r = 4, s = s, n = 8, a = 22.5)
+# Inner exterior angle of |8/3| star is 90 degrees (using `beta_ext`)
+d <- d_star(x = 5, y = 5, r = 4, n = 8, a = 22.5, beta_ext = 90)
 if (requireNamespace("omsvg", quietly = TRUE) &&
     requireNamespace("svgparser", quietly = TRUE)) {
   plot(d, height = 10, width = 10,
        fill = "yellow", stroke = "black", stroke_width = 4)
 }
 
-# Degenerate case of inner vertex with exterior angle
-# of 180 degrees creates a regular `n`-gon.
-s <- affiner::isotoxal_2ngon_inner_radius(n = 8, beta_ext = 180)
-d <- d_star(x = 5, y = 5, r = 4, s = s, n = 8, a = 22.5)
+# Degenerate case of inner vertex with exterior angle of 180 degrees
+# creates a regular `n`-gon.
+d <- d_star(x = 5, y = 5, r = 4, n = 8, a = 22.5, beta_ext = 180)
 if (requireNamespace("omsvg", quietly = TRUE) &&
     requireNamespace("svgparser", quietly = TRUE)) {
   plot(d, height = 10, width = 10,
@@ -100,5 +117,8 @@ if (requireNamespace("omsvg", quietly = TRUE) &&
 }
 }
 \seealso{
-\code{\link[=d_polygon]{d_polygon()}} and \code{\link[=d_regular_ngon]{d_regular_ngon()}}.  See \url{https://en.wikipedia.org/wiki/Isotoxal_figure#Isotoxal_polygons} and \url{https://en.wikipedia.org/wiki/Star_polygon#Isotoxal_star_simple_polygons} for more information on isotoxal polygons.
+\code{\link[=d_polygon]{d_polygon()}} and \code{\link[=d_regular_ngon]{d_regular_ngon()}}.  See
+\url{https://en.wikipedia.org/wiki/Isotoxal_figure#Isotoxal_polygons} and
+\url{https://en.wikipedia.org/wiki/Star_polygon#Isotoxal_star_simple_polygons}
+for more information on isotoxal polygons.
 }

--- a/tests/testthat/_snaps/isotoxal-2ngon.md
+++ b/tests/testthat/_snaps/isotoxal-2ngon.md
@@ -1,0 +1,16 @@
+# `d_isotoxal_2ngon()` `s` shortcuts
+
+    Code
+      d_isotoxal_2ngon(5, 5, 3, n = 8)
+    Condition
+      Error in `affiner::isotoxal_2ngon_inner_radius()`:
+      ! is.null(alpha) + is.null(beta_ext) + is.null(d) == 2L is not TRUE
+
+---
+
+    Code
+      d_isotoxal_2ngon(5, 5, 3, n = 8, d = 2, alpha = 45)
+    Condition
+      Error in `affiner::isotoxal_2ngon_inner_radius()`:
+      ! is.null(alpha) + is.null(beta_ext) + is.null(d) == 2L is not TRUE
+

--- a/tests/testthat/test-isotoxal-2ngon.R
+++ b/tests/testthat/test-isotoxal-2ngon.R
@@ -1,13 +1,34 @@
 test_that("`d_isotoxal_2ngon()`", {
 	do.call(rlang::local_options, dee_options(default = TRUE))
-	d <- d_isotoxal_2ngon(5, 5, 3, 2 / 3, 5)
+	d <- d_isotoxal_2ngon(5, 5, 3, 5, s = 2 / 3)
 	expect_s3_class(d, "dee")
 	# plot(d, height = 10, width = 10, fill = "red")
 
 	rlang::local_options(dee.origin_at_bottom = TRUE, dee.height = 10)
-	d <- d_isotoxal_2ngon(5, 5, 3, 2 / 3, 5)
+	d <- d_isotoxal_2ngon(5, 5, 3, 5, s = 2 / 3)
 	expect_s3_class(d, "dee")
 	# plot(d, height = 10, width = 10, fill = "red")
+})
+
+test_that("`d_isotoxal_2ngon()` `s` shortcuts", {
+	do.call(rlang::local_options, dee_options(default = TRUE))
+	s <- affiner::isotoxal_2ngon_inner_radius(5, d = 2)
+	expect_equal(
+		d_isotoxal_2ngon(5, 5, 3, n = 5, d = 2),
+		d_isotoxal_2ngon(5, 5, 3, s = s, n = 5)
+	)
+	s <- affiner::isotoxal_2ngon_inner_radius(8, alpha = 45)
+	expect_equal(
+		d_isotoxal_2ngon(5, 5, 3, n = 8, alpha = 45),
+		d_isotoxal_2ngon(5, 5, 3, s = s, n = 8)
+	)
+	s <- affiner::isotoxal_2ngon_inner_radius(8, beta_ext = 90)
+	expect_equal(
+		d_isotoxal_2ngon(5, 5, 3, n = 8, beta_ext = 90),
+		d_isotoxal_2ngon(5, 5, 3, s = s, n = 8)
+	)
+	expect_snapshot(error = TRUE, d_isotoxal_2ngon(5, 5, 3, n = 8))
+	expect_snapshot(error = TRUE, d_isotoxal_2ngon(5, 5, 3, n = 8, d = 2, alpha = 45))
 })
 
 test_that("`d_regular_ngon()`", {


### PR DESCRIPTION
`s` now defaults to `affiner::isotoxal_2ngon_inner_radius(n, alpha = alpha, beta_ext = beta_ext, d = d)`,
making the shortcut args the primary interface. Requires {affiner} >= 0.3.1.

BREAKING CHANGE: `s` is now a keyword-only argument after `...`; positional calls like `d_isotoxal_2ngon(x, y, r, s, n)` must be updated to `d_isotoxal_2ngon(x, y, r, n, s = s)`.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
