### PR TITLE
feat: Switch from {svgparser} to {nanosvgr} for plotting dee objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,16 +1,17 @@
 Package: dee
 Type: Package
-Title: 'd' Attribute Tools to Construct SVG Paths
-Version: 0.1.0-28
+Title: Tools to Construct SVG Path 'd' Attributes
+Version: 0.1.0-29
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")))
 URL: https://github.com/trevorld/dee, https://trevorldavis.com/R/dee/dev/
 BugReports: https://github.com/trevorld/dee/issues
 Description: Provides helper functions to construct the SVG path 'd' <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d> attribute string.
-	Supports all standard SVG path commands including moveto, lineto, closepath, quadratic and cubic Bézier curves, and elliptical arc curves.
-	Also provides convenience wrappers for common shapes such as rectangles, ellipses, circles, polygons, regular n-gons, isotoxal 2n-gons (stars), and backward/forward slashes.
-	Coordinates may be supplied as numeric vectors or as 'affiner' coordinate objects and an option is available to use a bottom-left origin (as is conventional in R graphics) rather than the top-left origin used by SVG.
+	Supports all standard SVG path commands including 'moveto', 'lineto', 'closepath', quadratic and cubic Bézier curves, and elliptical arc curves.
+	Also provides convenience wrappers for common shapes such as arcs, circles, ellipses, polygons, slashes, and stars.
+	Coordinates may be supplied as numeric vectors or as 'affiner' coordinate objects and an option is available to automatically round them to a target number of decimal places for more compact svg strings.
+	An option is also available to use a bottom-left origin (as is conventional in R graphics) rather than the top-left origin used by SVG.
 Depends:
     R (>= 4.2)
 Imports:
@@ -20,9 +21,9 @@ Imports:
 	utils
 Suggests:
 	grDevices,
+	nanosvgr,
 	omsvg,
 	polyclip,
-	svgparser,
 	testthat
 Additional_repositories: https://trevorld.r-universe.dev
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ Initial features
 
 * `dee()` creates "dee" class objects.
 
-  + Can be plotted with `plot.dee()` if suggested packages `{omsvg}` and `{svgparser}` are installed.
+  + Can be plotted with `plot.dee()` if suggested packages `{omsvg}` and `{nanosvgr}` are installed.
   + Can be converted to an `{omsvg}` "svg" class object with `as_omsvg()` if suggested package `{omsvg}` is installed.
 
 * `dee_options()` returns a list of (current or default) `{dee}` package option values.

--- a/R/arc.R
+++ b/R/arc.R
@@ -40,25 +40,25 @@ arc_setup <- function(y_top, x_right, y_bottom, x_left, w, origin_at_bottom, hei
 #' @examples
 #' d_1 <- d_arc1(2, 8, 8, 2, 1)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d_1, height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }
 #' d_2 <- d_arc2(2, 8, 8, 2, 1)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d_2, height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }
 #' d_34 <- d_arc34(2, 8, 8, 2, 1)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d_34, height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }
 #' d_412 <- d_arc412(2, 8, 8, 2, 1)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d_412, height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }

--- a/R/dee.R
+++ b/R/dee.R
@@ -128,9 +128,9 @@ as_omsvg <- function(
 
 #' Plot an object of class "dee"
 #'
-#' `plot()` an object of class "dee" using [omsvg::SVG()], [omsvg::svg_path()], and `svgparser::read_svg()`.
+#' `plot()` an object of class "dee" using [omsvg::SVG()], [omsvg::svg_path()], and `nanosvgr::nsvg_read()`.
 #'
-#' This function requires the package `svgparser` which (as of January 2026) is not available on CRAN.  You can install it with `remotes::install_github('coolbutuseless/svgparser')` or `utils::install.packages('svgparser', repos = c('https://trevorld.r-universe.dev', 'https://cloud.r-project.org'))`.
+#' This function requires the package `nanosvgr` which (as of May 2026) is not available on CRAN.  You can install it with `remotes::install_github('coolbutuseless/nanosvgr')` or `utils::install.packages('nanosvgr', repos = c('https://trevorld.r-universe.dev', 'https://cloud.r-project.org'))`.
 #'
 #' @inheritParams as_omsvg
 #' @return `invisible(NULL)`
@@ -143,7 +143,7 @@ as_omsvg <- function(
 #'      Q(10, 60, 10, 30) +
 #'      Z()
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d, height = 100, width = 100, background_color = "cyan",
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }
@@ -159,9 +159,9 @@ plot.dee <- function(
 	fill = getOption("dee.fill"),
 	attrs = getOption("dee.attrs")
 ) {
-	rlang::check_installed("svgparser", action = function(...) {
+	rlang::check_installed("nanosvgr", action = function(...) {
 		utils::install.packages(
-			'svgparser',
+			'nanosvgr',
 			repos = c('https://trevorld.r-universe.dev', 'https://cloud.r-project.org')
 		)
 	})
@@ -176,9 +176,11 @@ plot.dee <- function(
 		fill = fill,
 		attrs = attrs
 	)
-	g <- as.character(svg) |>
-		paste(collapse = "\n") |>
-		svgparser::read_svg()
+	f <- tempfile(fileext = ".svg")
+	on.exit(unlink(f))
+	writeLines(as.character(svg), f)
+	g <- nanosvgr::nsvg_read(f) |>
+		nanosvgr::nsvg_to_grob()
 	grid::grid.newpage()
 	grid::grid.draw(g)
 	invisible(NULL)

--- a/R/dee.R
+++ b/R/dee.R
@@ -179,10 +179,24 @@ plot.dee <- function(
 	f <- tempfile(fileext = ".svg")
 	on.exit(unlink(f))
 	writeLines(as.character(svg), f)
-	g <- nanosvgr::nsvg_read(f) |>
-		nanosvgr::nsvg_to_grob()
+	nsvg <- nanosvgr::nsvg_read(f)
+	max_y <- max(do.call(rbind, nsvg$points)$y)
+	g <- nanosvgr::nsvg_to_grob(nsvg)
+	for (i in seq_along(g$children)) {
+		child <- g$children[[i]]
+		child$x <- grid::unit(as.numeric(child$x) / width, "npc")
+		child$y <- grid::unit((as.numeric(child$y) + height - max_y) / height, "npc")
+		g$children[[i]] <- child
+	}
+	max_dim <- max(width, height)
+	vp <- grid::viewport(
+		width = grid::unit(width / max_dim, "snpc"),
+		height = grid::unit(height / max_dim, "snpc")
+	)
 	grid::grid.newpage()
+	grid::pushViewport(vp)
 	grid::grid.draw(g)
+	grid::popViewport()
 	invisible(NULL)
 }
 

--- a/R/isotoxal_2ngon.R
+++ b/R/isotoxal_2ngon.R
@@ -33,14 +33,14 @@
 #' # A |5/2| star e.g. the *verda stelo* (using `d` shortcut)
 #' d <- d_isotoxal_2ngon(x = 5, y = 5, r = 3, n = 5, d = 2)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d, height = 10, width = 10,
 #'        fill = "green", stroke = "none")
 #' }
 #' # "lozenge" shape most often has acute angles of 45 degrees (using `alpha`)
 #' d <- d_isotoxal_2ngon(x = 5, y = 5, r = 4, n = 2, alpha = 45)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d, height = 10, width = 10,
 #'        fill = "cyan", stroke = "black", stroke_width = 4)
 #' }
@@ -48,7 +48,7 @@
 #' # Inner exterior angle of |8/3| star is 90 degrees (using `beta_ext`)
 #' d <- d_star(x = 5, y = 5, r = 4, n = 8, a = 22.5, beta_ext = 90)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d, height = 10, width = 10,
 #'        fill = "yellow", stroke = "black", stroke_width = 4)
 #' }
@@ -57,7 +57,7 @@
 #' # creates a regular `n`-gon.
 #' d <- d_star(x = 5, y = 5, r = 4, n = 8, a = 22.5, beta_ext = 180)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d, height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }
@@ -146,14 +146,14 @@ d_isotoxal_2ngon_helper <- function(x, y, r, s, n, a, offset, ...) {
 #' # A pentagon
 #' d5 <- d_regular_ngon(x = 5, y = 5, r = 4, n = 5)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d5, height = 10, width = 10,
 #'        fill = "magenta", stroke = "black", stroke_width = 4)
 #' }
 #' # A hexagon
 #' d6 <- d_regular_ngon(x = 5, y = 5, r = 4, n = 6, offset = c(0, -1))
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d6, height = 10, width = 10,
 #'        attrs = list(fill_rule = "evenodd"),
 #'        fill = "magenta", stroke = "black", stroke_width = 4)

--- a/R/path.R
+++ b/R/path.R
@@ -32,7 +32,7 @@ zz <- function() dee("z")
 #' M(1, 1) + ll(1, 1) + zz()
 #' d <- MZ(x = c(2, 5, 8, 5), y = c(5, 8, 5, 2))
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d, height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }
@@ -107,7 +107,7 @@ mz <- function(...) {
 #' M(1, 1) + ll(1, 1) + zz()
 #' d <- M(1,1) + L(5,8) + H(8) + V(3) + Z()
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d, height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }
@@ -609,7 +609,7 @@ sz <- function(...) {
 #' d_big_ccw <- M(40, 70) + A(rx = 20, ry = 30, x = 20, y = 20, big = TRUE)
 #' d_big_cw <- M(40, 70) + A(rx = 20, ry = 30, x = 20, y = 20, big = TRUE, cw = TRUE)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(c(d_small_ccw, d_small_cw, d_big_ccw, d_big_cw),
 #'     height = 100, width = 100,
 #'     stroke = c("black", "grey", "blue", "cyan"),

--- a/R/path_wrappers.R
+++ b/R/path_wrappers.R
@@ -9,7 +9,7 @@
 #' @examples
 #' d_aabb(x = 2:6, y = 4:8)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d_aabb(x = 2:6, y = 4:8),
 #'        height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
@@ -47,7 +47,7 @@ d_aabb <- function(
 #' @examples
 #' d_rect(x = 5, y = 5, w = 4, h = 6)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d_rect(x = 5, y = 5, w = 4, h = 6),
 #'        height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
@@ -105,7 +105,7 @@ d_rect_helper <- function(x, y, w, h, a, ...) {
 #' d_circle(x = 5, y = 5, r = 2)
 #' d_ellipse(x = 5, y = 5, rx = 2, ry = 3)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d_ellipse(x = 5, y = 5, rx = 2, ry = 3),
 #'        height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
@@ -167,7 +167,7 @@ d_ellipse_helper <- function(x, y, rx, ry, a, ...) {
 #' l <- list(x = c(2, 5, 8, 5), y = c(5, 8, 5, 2))
 #' d <- d_polygon(l, offset = c(1, 0, -1))
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d, height = 10, width = 10,
 #'        attrs = list(fill_rule = "evenodd"),
 #'        fill = "red", stroke = "black", stroke_width = 4)

--- a/R/slash.R
+++ b/R/slash.R
@@ -17,25 +17,25 @@
 #' @examples
 #' d_h <- d_fslash(2, 8, 8, 2, 1)
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d_h, height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }
 #' d_s <- d_bslash(2, 8, 8, 2, 1, nib = "square")
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d_s, height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }
 #' d_v <- d_fslash(2, 8, 8, 2, 1, nib = "vertical")
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d_v, height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }
 #' d_d <- d_bslash(2, 8, 8, 2, 1, nib = "diagonal")
 #' if (requireNamespace("omsvg", quietly = TRUE) &&
-#'     requireNamespace("svgparser", quietly = TRUE)) {
+#'     requireNamespace("nanosvgr", quietly = TRUE)) {
 #'   plot(d_d, height = 10, width = 10,
 #'        fill = "red", stroke = "black", stroke_width = 4)
 #' }

--- a/README.Rmd
+++ b/README.Rmd
@@ -131,4 +131,5 @@ R packages:
 
 * [omsvg](https://github.com/rich-iannone/omsvg)
 * [svglite](https://github.com/r-lib/svglite)
+* [nanosvgr](https://github.com/coolbutuseless/nanosvgr)
 * [svgparser](https://github.com/coolbutuseless/svgparser)

--- a/README.md
+++ b/README.md
@@ -186,4 +186,5 @@ R packages:
 
 * [omsvg](https://github.com/rich-iannone/omsvg)
 * [svglite](https://github.com/r-lib/svglite)
+* [nanosvgr](https://github.com/coolbutuseless/nanosvgr)
 * [svgparser](https://github.com/coolbutuseless/svgparser)

--- a/man/A.Rd
+++ b/man/A.Rd
@@ -90,7 +90,7 @@ d_small_cw <- M(40, 70) + A(rx = 20, ry = 30, x = 20, y = 20, cw = TRUE)
 d_big_ccw <- M(40, 70) + A(rx = 20, ry = 30, x = 20, y = 20, big = TRUE)
 d_big_cw <- M(40, 70) + A(rx = 20, ry = 30, x = 20, y = 20, big = TRUE, cw = TRUE)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(c(d_small_ccw, d_small_cw, d_big_ccw, d_big_cw),
     height = 100, width = 100,
     stroke = c("black", "grey", "blue", "cyan"),

--- a/man/L.Rd
+++ b/man/L.Rd
@@ -97,7 +97,7 @@ M(1, 1) + L(2, 2) + Z()
 M(1, 1) + ll(1, 1) + zz()
 d <- M(1,1) + L(5,8) + H(8) + V(3) + Z()
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d, height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)
 }

--- a/man/M.Rd
+++ b/man/M.Rd
@@ -59,7 +59,7 @@ M(1, 1) + L(2, 2) + Z()
 M(1, 1) + ll(1, 1) + zz()
 d <- MZ(x = c(2, 5, 8, 5), y = c(5, 8, 5, 2))
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d, height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)
 }

--- a/man/d_aabb.Rd
+++ b/man/d_aabb.Rd
@@ -24,7 +24,7 @@ an axis-aligned bounding box path.
 \examples{
 d_aabb(x = 2:6, y = 4:8)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d_aabb(x = 2:6, y = 4:8),
        height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)

--- a/man/d_arc.Rd
+++ b/man/d_arc.Rd
@@ -174,25 +174,25 @@ and give an indication of what the shape of the arc looks like.
 \examples{
 d_1 <- d_arc1(2, 8, 8, 2, 1)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d_1, height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)
 }
 d_2 <- d_arc2(2, 8, 8, 2, 1)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d_2, height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)
 }
 d_34 <- d_arc34(2, 8, 8, 2, 1)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d_34, height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)
 }
 d_412 <- d_arc412(2, 8, 8, 2, 1)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d_412, height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)
 }

--- a/man/d_ellipse.Rd
+++ b/man/d_ellipse.Rd
@@ -50,7 +50,7 @@ It's vectorized in its \code{x}, \code{y}, and \code{r} arguments.
 d_circle(x = 5, y = 5, r = 2)
 d_ellipse(x = 5, y = 5, rx = 2, ry = 3)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d_ellipse(x = 5, y = 5, rx = 2, ry = 3),
        height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)

--- a/man/d_fslash.Rd
+++ b/man/d_fslash.Rd
@@ -61,25 +61,25 @@ and \code{w} arguments.
 \examples{
 d_h <- d_fslash(2, 8, 8, 2, 1)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d_h, height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)
 }
 d_s <- d_bslash(2, 8, 8, 2, 1, nib = "square")
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d_s, height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)
 }
 d_v <- d_fslash(2, 8, 8, 2, 1, nib = "vertical")
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d_v, height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)
 }
 d_d <- d_bslash(2, 8, 8, 2, 1, nib = "diagonal")
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d_d, height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)
 }

--- a/man/d_isotoxal_2ngon.Rd
+++ b/man/d_isotoxal_2ngon.Rd
@@ -87,14 +87,14 @@ Its vectorized in its \code{x}, \code{y}, \code{r}, \code{n}, \code{a}, \code{s}
 # A |5/2| star e.g. the *verda stelo* (using `d` shortcut)
 d <- d_isotoxal_2ngon(x = 5, y = 5, r = 3, n = 5, d = 2)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d, height = 10, width = 10,
        fill = "green", stroke = "none")
 }
 # "lozenge" shape most often has acute angles of 45 degrees (using `alpha`)
 d <- d_isotoxal_2ngon(x = 5, y = 5, r = 4, n = 2, alpha = 45)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d, height = 10, width = 10,
        fill = "cyan", stroke = "black", stroke_width = 4)
 }
@@ -102,7 +102,7 @@ if (requireNamespace("omsvg", quietly = TRUE) &&
 # Inner exterior angle of |8/3| star is 90 degrees (using `beta_ext`)
 d <- d_star(x = 5, y = 5, r = 4, n = 8, a = 22.5, beta_ext = 90)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d, height = 10, width = 10,
        fill = "yellow", stroke = "black", stroke_width = 4)
 }
@@ -111,7 +111,7 @@ if (requireNamespace("omsvg", quietly = TRUE) &&
 # creates a regular `n`-gon.
 d <- d_star(x = 5, y = 5, r = 4, n = 8, a = 22.5, beta_ext = 180)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d, height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)
 }

--- a/man/d_polygon.Rd
+++ b/man/d_polygon.Rd
@@ -43,7 +43,7 @@ It's vectorized in its \code{offset} argument.
 l <- list(x = c(2, 5, 8, 5), y = c(5, 8, 5, 2))
 d <- d_polygon(l, offset = c(1, 0, -1))
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d, height = 10, width = 10,
        attrs = list(fill_rule = "evenodd"),
        fill = "red", stroke = "black", stroke_width = 4)

--- a/man/d_rect.Rd
+++ b/man/d_rect.Rd
@@ -42,7 +42,7 @@ It's vectorized in its \code{x}, \code{y}, \code{w}, and \code{h} arguments.
 \examples{
 d_rect(x = 5, y = 5, w = 4, h = 6)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d_rect(x = 5, y = 5, w = 4, h = 6),
        height = 10, width = 10,
        fill = "red", stroke = "black", stroke_width = 4)

--- a/man/d_regular_ngon.Rd
+++ b/man/d_regular_ngon.Rd
@@ -48,14 +48,14 @@ Its vectorized in its \code{x}, \code{y}, \code{r}, \code{n}, \code{a}, and \cod
 # A pentagon
 d5 <- d_regular_ngon(x = 5, y = 5, r = 4, n = 5)
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d5, height = 10, width = 10,
        fill = "magenta", stroke = "black", stroke_width = 4)
 }
 # A hexagon
 d6 <- d_regular_ngon(x = 5, y = 5, r = 4, n = 6, offset = c(0, -1))
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d6, height = 10, width = 10,
        attrs = list(fill_rule = "evenodd"),
        fill = "magenta", stroke = "black", stroke_width = 4)

--- a/man/dee-package.Rd
+++ b/man/dee-package.Rd
@@ -3,9 +3,9 @@
 \docType{package}
 \name{dee-package}
 \alias{dee-package}
-\title{dee: 'd' Attribute Tools}
+\title{dee: Tools to Construct SVG Path 'd' Attributes}
 \description{
-Utilities to build an svg path 'd' \url{https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d} attribute.
+Provides helper functions to construct the SVG path 'd' \url{https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d} attribute string. Supports all standard SVG path commands including 'moveto', 'lineto', 'closepath', quadratic and cubic Bézier curves, and elliptical arc curves. Also provides convenience wrappers for common shapes such as arcs, circles, ellipses, polygons, slashes, and stars. Coordinates may be supplied as numeric vectors or as 'affiner' coordinate objects and an option is available to automatically round them to a target number of decimal places for more compact svg strings. An option is also available to use a bottom-left origin (as is conventional in R graphics) rather than the top-left origin used by SVG.
 }
 \section{Package options}{
 

--- a/man/plot.dee.Rd
+++ b/man/plot.dee.Rd
@@ -31,10 +31,10 @@
 \code{invisible(NULL)}
 }
 \description{
-\code{plot()} an object of class "dee" using \code{\link[omsvg:SVG]{omsvg::SVG()}}, \code{\link[omsvg:svg_path]{omsvg::svg_path()}}, and \code{svgparser::read_svg()}.
+\code{plot()} an object of class "dee" using \code{\link[omsvg:SVG]{omsvg::SVG()}}, \code{\link[omsvg:svg_path]{omsvg::svg_path()}}, and \code{nanosvgr::nsvg_read()}.
 }
 \details{
-This function requires the package \code{svgparser} which (as of January 2026) is not available on CRAN.  You can install it with \code{remotes::install_github('coolbutuseless/svgparser')} or \code{utils::install.packages('svgparser', repos = c('https://trevorld.r-universe.dev', 'https://cloud.r-project.org'))}.
+This function requires the package \code{nanosvgr} which (as of May 2026) is not available on CRAN.  You can install it with \code{remotes::install_github('coolbutuseless/nanosvgr')} or \code{utils::install.packages('nanosvgr', repos = c('https://trevorld.r-universe.dev', 'https://cloud.r-project.org'))}.
 }
 \examples{
 d <- M(10, 30) +
@@ -44,7 +44,7 @@ d <- M(10, 30) +
      Q(10, 60, 10, 30) +
      Z()
 if (requireNamespace("omsvg", quietly = TRUE) &&
-    requireNamespace("svgparser", quietly = TRUE)) {
+    requireNamespace("nanosvgr", quietly = TRUE)) {
   plot(d, height = 100, width = 100, background_color = "cyan",
        fill = "red", stroke = "black", stroke_width = 4)
 }

--- a/tests/testthat/test-dee.R
+++ b/tests/testthat/test-dee.R
@@ -26,7 +26,7 @@ test_that("`dee()`", {
 	expect_snapshot(error = TRUE, ds[[5L]] <- "boo")
 
 	skip_if_not_installed("omsvg")
-	skip_if_not_installed("svgparser")
+	skip_if_not_installed("nanosvgr")
 	grDevices::pdf(NULL)
 	plot(d, height = 100, width = 100, stroke = "black", stroke_width = 4)
 	invisible(grDevices::dev.off())


### PR DESCRIPTION
Replaces the svgparser dependency with nanosvgr (recommended by the
svgparser maintainer) in plot.dee(), DESCRIPTION, examples, docs, and tests.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
